### PR TITLE
[#3] Implement interactive calculator with validation

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -78,31 +78,63 @@
 
       <section id="calculator" aria-labelledby="calculator-title">
         <h2 id="calculator-title">Calculator</h2>
-        <!-- Placeholder form only; calculator logic is out of scope for this issue. -->
-        <form action="#" method="get" aria-describedby="calculator-note">
+
+        <form id="dv-form" novalidate aria-describedby="calculator-note">
           <fieldset>
-            <legend>Inputs (placeholder)</legend>
+            <legend>Compute Δv from Isp and masses</legend>
 
             <p>
-              <label for="ve">Effective exhaust velocity (v<sub>e</sub>)</label>
-              <input id="ve" name="ve" inputmode="decimal" autocomplete="off" />
+              <label for="isp">Isp (specific impulse, seconds)</label>
+              <input
+                id="isp"
+                name="isp"
+                type="number"
+                inputmode="decimal"
+                min="0"
+                step="any"
+                required
+                autocomplete="off"
+              />
             </p>
 
             <p>
-              <label for="m0">Initial mass (m<sub>0</sub>)</label>
-              <input id="m0" name="m0" inputmode="decimal" autocomplete="off" />
+              <label for="m0">Wet mass, m<sub>0</sub> (kg)</label>
+              <input
+                id="m0"
+                name="m0"
+                type="number"
+                inputmode="decimal"
+                min="0"
+                step="any"
+                required
+                autocomplete="off"
+              />
             </p>
 
             <p>
-              <label for="mf">Final mass (m<sub>f</sub>)</label>
-              <input id="mf" name="mf" inputmode="decimal" autocomplete="off" />
+              <label for="mf">Dry mass, m<sub>f</sub> (kg)</label>
+              <input
+                id="mf"
+                name="mf"
+                type="number"
+                inputmode="decimal"
+                min="0"
+                step="any"
+                required
+                autocomplete="off"
+              />
             </p>
 
             <p>
-              <button type="button" disabled>Compute Δv (coming soon)</button>
+              <button type="submit">Compute Δv</button>
             </p>
 
-            <p id="calculator-note">Calculator functionality will be implemented in a separate task.</p>
+            <p id="calculator-note">
+              Uses <code>Δv = Isp × 9.80665 × ln(m<sub>0</sub>/m<sub>f</sub>)</code>
+            </p>
+
+            <p id="calc-error" role="alert" aria-live="polite" hidden></p>
+            <p id="calc-result" aria-live="polite" hidden></p>
           </fieldset>
         </form>
       </section>

--- a/site/script.js
+++ b/site/script.js
@@ -1,1 +1,104 @@
-// JavaScript calculator logic will be added in a later task.
+/*
+  Rocket equation calculator (vanilla JS, no build step).
+
+  Computes:
+    Δv = Isp × g0 × ln(m0 / mf)
+  where g0 = 9.80665 m/s²
+*/
+
+(() => {
+  const G0 = 9.80665;
+
+  const numberFmt = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 0,
+  });
+
+  const kmPerSecFmt = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  function setMessage(el, message) {
+    if (!el) return;
+    el.textContent = message;
+    el.hidden = false;
+  }
+
+  function clearMessage(el) {
+    if (!el) return;
+    el.textContent = '';
+    el.hidden = true;
+  }
+
+  function readPositiveNumber(inputEl) {
+    const n = inputEl?.valueAsNumber;
+    if (!Number.isFinite(n)) return { ok: false, value: NaN };
+    if (n <= 0) return { ok: false, value: n };
+    return { ok: true, value: n };
+  }
+
+  function computeDeltaV({ isp, m0, mf }) {
+    return isp * G0 * Math.log(m0 / mf);
+  }
+
+  function init() {
+    const form = document.getElementById('dv-form');
+    if (!form) return;
+
+    const ispEl = document.getElementById('isp');
+    const m0El = document.getElementById('m0');
+    const mfEl = document.getElementById('mf');
+    const errorEl = document.getElementById('calc-error');
+    const resultEl = document.getElementById('calc-result');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+
+      clearMessage(errorEl);
+      clearMessage(resultEl);
+
+      const isp = readPositiveNumber(ispEl);
+      if (!isp.ok) {
+        setMessage(errorEl, 'Isp must be a positive number.');
+        return;
+      }
+
+      const m0 = readPositiveNumber(m0El);
+      if (!m0.ok) {
+        setMessage(errorEl, 'Wet mass (m0) must be a positive number.');
+        return;
+      }
+
+      const mf = readPositiveNumber(mfEl);
+      if (!mf.ok) {
+        setMessage(errorEl, 'Dry mass (mf) must be a positive number.');
+        return;
+      }
+
+      if (m0.value <= mf.value) {
+        setMessage(errorEl, 'Wet mass must be greater than dry mass.');
+        return;
+      }
+
+      const dv = computeDeltaV({ isp: isp.value, m0: m0.value, mf: mf.value });
+      if (!Number.isFinite(dv) || dv <= 0) {
+        setMessage(errorEl, 'Inputs produced an invalid Δv. Please double-check your numbers.');
+        return;
+      }
+
+      const dvMs = Math.round(dv);
+      const dvKms = dv / 1000;
+
+      setMessage(
+        resultEl,
+        `${numberFmt.format(dvMs)} m/s (${kmPerSecFmt.format(dvKms)} km/s)`
+      );
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
<!-- agent:worker to:verifier type:pr-ready -->

## Summary
- Replaced the placeholder calculator form with numeric inputs for Isp (s), wet mass m0 (kg), and dry mass mf (kg).
- Added vanilla JS to validate inputs and compute Δv = Isp × 9.80665 × ln(m0/mf), displaying both m/s and km/s with readable formatting.

## Notes
- Using the issue's stated formula + constants, the provided example (Isp=282, m0=433100, mf=25600) yields ~7,822 m/s (7.82 km/s). The issue text says ~7,651 m/s; please confirm the expected example value.

## How to test
1. Run: cd site && python3 -m http.server 8000
2. Open: http://localhost:8000 and scroll to **Calculator**.
3. Valid: enter Isp=282, m0=433100, mf=25600 → result ~7,822 m/s (7.82 km/s).
4. Invalid: set mf > m0 → error "Wet mass must be greater than dry mass."
5. Invalid: set Isp=0 (or blank) → error.
6. Re-submit multiple times: old messages clear; no page reload.

Closes #3
