### PR TITLE
[#5] Add Falcon 9 worked example with real numbers

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,92 @@
 
     <!-- Optional stubs; real styling/logic will be added in later tasks. -->
     <link rel="stylesheet" href="./style.css" />
+
+    <!-- Inline CSS so GitHub Pages can ship as-is without touching site/style.css. -->
+    <style>
+      .example-card {
+        border: 1px solid #d1d5db;
+        border-radius: 12px;
+        padding: 1rem;
+        background: #f8fafc;
+        max-width: 60rem;
+      }
+      .example-card h3 {
+        margin-top: 0;
+      }
+      .example-grid {
+        display: grid;
+        gap: 0.5rem;
+        grid-template-columns: 1fr;
+        margin: 0.75rem 0;
+      }
+      @media (min-width: 720px) {
+        .example-grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .example-kv {
+        border: 1px solid #e5e7eb;
+        border-radius: 10px;
+        padding: 0.75rem;
+        background: #ffffff;
+      }
+      .example-kv p {
+        margin: 0.25rem 0;
+      }
+      .example-actions {
+        margin-top: 0.75rem;
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .muted {
+        color: #334155;
+      }
+    </style>
+
     <script src="./script.js" defer></script>
+
+    <!-- Optionally load the Falcon 9 numbers into the calculator (kept here so only index.html changes). -->
+    <script defer>
+      (() => {
+        const EXAMPLE = { isp: 282, m0: 433100, mf: 25600 };
+
+        function init() {
+          const btn = document.getElementById('load-falcon9');
+          if (!btn) return;
+
+          btn.addEventListener('click', () => {
+            const ispEl = document.getElementById('isp');
+            const m0El = document.getElementById('m0');
+            const mfEl = document.getElementById('mf');
+            const form = document.getElementById('dv-form');
+
+            if (ispEl) ispEl.value = String(EXAMPLE.isp);
+            if (m0El) m0El.value = String(EXAMPLE.m0);
+            if (mfEl) mfEl.value = String(EXAMPLE.mf);
+
+            document.getElementById('calculator')?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'start',
+            });
+
+            if (form?.requestSubmit) {
+              form.requestSubmit();
+            } else {
+              form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            }
+          });
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', init);
+        } else {
+          init();
+        }
+      })();
+    </script>
   </head>
 
   <body>
@@ -188,13 +273,79 @@
 
       <section id="worked-example" aria-labelledby="worked-example-title">
         <h2 id="worked-example-title">Worked example</h2>
-        <!-- TODO(#2): Add a worked example with numbers in a later task. -->
-        <article>
-          <h3>Example (placeholder)</h3>
+
+        <!--
+          Falcon 9 Stage 1 worked example (ideal rocket-equation calculation).
+
+          Sources / assumptions:
+          - Masses: SpaceX Falcon 9 User’s Guide PDF (Stage 1) lists ~433,100 kg (gross/wet) and
+            ~25,600 kg (dry). Source: https://www.spacex.com/media/Falcon_9_User_Guide.pdf
+          - Engine: Merlin 1D Isp is commonly cited as ~282 s at sea level and ~311 s in vacuum.
+            We use the sea-level value here because Stage 1 begins its burn in the atmosphere.
+
+          Notes:
+          - This Δv is an *ideal* “speed budget” from the rocket equation (ignores gravity + drag
+            losses and assumes constant performance). Real ascent to orbit requires more.
+        -->
+
+        <article class="example-card" aria-label="Worked example: Falcon 9 Stage 1">
+          <h3>Falcon 9 Stage 1 (Block 5) — plug in real numbers</h3>
+
+          <div class="example-grid">
+            <div class="example-kv">
+              <p><strong>Inputs</strong></p>
+              <p><code>Isp</code> ≈ <strong>282 s</strong> (sea level)</p>
+              <p><code>m<sub>0</sub></code> ≈ <strong>433,100 kg</strong> (wet mass)</p>
+              <p><code>m<sub>f</sub></code> ≈ <strong>25,600 kg</strong> (dry mass)</p>
+            </div>
+
+            <div class="example-kv">
+              <p><strong>Result</strong></p>
+              <p>
+                <code>Δv = Isp × 9.80665 × ln(m<sub>0</sub>/m<sub>f</sub>)</code>
+              </p>
+              <p>
+                <strong>Δv ≈ 7,822 m/s</strong> (<strong>7.82 km/s</strong>)
+              </p>
+              <p class="muted">
+                (This is the ideal value from the equation for these inputs.)
+              </p>
+            </div>
+          </div>
+
+          <details>
+            <summary>Show the step-by-step calculation</summary>
+            <ol>
+              <li>
+                Mass ratio:
+                <code>m<sub>0</sub>/m<sub>f</sub> = 433100 / 25600 ≈ 16.914</code>
+              </li>
+              <li>
+                Natural log:
+                <code>ln(m<sub>0</sub>/m<sub>f</sub>) ≈ ln(16.914) ≈ 2.828</code>
+              </li>
+              <li>
+                Plug into the equation:
+                <code>Δv ≈ 282 × 9.80665 × 2.828 ≈ 7822 m/s</code>
+              </li>
+            </ol>
+          </details>
+
           <p>
-            This section will walk through a concrete example step-by-step and show the Δv
-            result.
+            <strong>What does ~7.8 km/s mean?</strong> Δv is a rocket’s “speed budget” in an ideal world.
+            A value around 7–8 km/s is in the same ballpark as the speed needed for low Earth orbit
+            (about 7.8 km/s), but real launches need <em>more</em> than orbital speed because gravity and
+            air drag steal some of that budget while you climb.
           </p>
+          <p>
+            That’s why Falcon 9 needs a <strong>second stage</strong>: Stage 1 provides a huge push early on,
+            then Stage 2 continues accelerating above most of the atmosphere to reach orbit.
+          </p>
+
+          <div class="example-actions">
+            <button type="button" id="load-falcon9">Load these numbers into the calculator</button>
+            <span class="muted">(You should see ~7,822 m/s.)</span>
+          </div>
         </article>
       </section>
 


### PR DESCRIPTION
<!-- agent:worker to:verifier type:pr-ready -->

### Summary
- Adds a visually distinct Falcon 9 Stage 1 worked example card (inputs, step-by-step math, and plain-language interpretation).
- Adds a "Load these numbers into the calculator" button to prefill and compute, so learners can verify the calculator result.

### How to test
1. In one terminal: cd site; python3 -m http.server 8000
2. Open http://127.0.0.1:8000/
3. Scroll to Worked example → Falcon 9 Stage 1 (Block 5).
4. Click Load these numbers into the calculator (or manually enter Isp=282, m0=433100, mf=25600).
5. Confirm the calculator shows ~7,822 m/s (7.82 km/s) and matches the example card.

Closes #5
