### PR TITLE
[#26] /designer.html — interactive N-stage rocket designer UI

### DIFF
--- a/docs/designer.css
+++ b/docs/designer.css
@@ -1,0 +1,185 @@
+.designer-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.designer-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.stage-count {
+  margin: 0;
+  font-weight: 700;
+}
+
+.stage-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stage-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  background: var(--surface-muted);
+}
+
+.stage-card h3 {
+  margin-top: 0;
+}
+
+.stage-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.stage-role {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.field-error {
+  color: var(--danger);
+  font-size: 0.95rem;
+  min-height: 1.4em;
+  margin: 0;
+}
+
+.input-invalid {
+  border-color: var(--danger) !important;
+  background: var(--danger-bg);
+}
+
+.stage-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.metric-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  padding: 0.75rem;
+}
+
+.metric-card h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.metric-value {
+  margin: 0;
+  font-weight: 700;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.summary-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-muted);
+  padding: 1rem;
+}
+
+.summary-card h3 {
+  margin-top: 0;
+}
+
+.summary-value {
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.callout {
+  border-radius: 12px;
+  padding: 0.75rem;
+  margin-top: 1rem;
+}
+
+.callout-danger {
+  color: var(--danger);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+}
+
+.callout-warning {
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+}
+
+.chart-figure {
+  margin-top: 1rem;
+}
+
+.velocity-chart {
+  width: 100%;
+  height: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.chart-axis,
+.chart-grid {
+  stroke: #cbd5e1;
+  stroke-width: 1;
+}
+
+.chart-axis {
+  stroke: #64748b;
+}
+
+.chart-line {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 4;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.chart-point {
+  fill: var(--primary);
+}
+
+.chart-boundary {
+  stroke: #94a3b8;
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+}
+
+.chart-label {
+  fill: var(--muted);
+  font-size: 14px;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
+
+.chart-stage-label {
+  fill: var(--muted);
+  font-size: 13px;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  text-anchor: middle;
+}
+
+button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+}

--- a/docs/designer.html
+++ b/docs/designer.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Interactively design a multi-stage rocket, inspect per-stage delta-v and thrust-to-weight ratio, and see a velocity chart update live."
+    />
+    <title>Multi-stage Rocket Designer</title>
+    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./designer.css" />
+    <script type="module" src="./designer.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Multi-stage rocket designer</h1>
+      <p>
+        Experiment with staged rockets using the shared core library: tune masses, Isp, thrust,
+        and payload to see how the stack changes in real time.
+      </p>
+
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="./index.html">Equation guide</a></li>
+          <li><a href="./designer.html" aria-current="page">Multi-stage designer</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main id="content">
+      <section aria-labelledby="designer-intro-title">
+        <h2 id="designer-intro-title">Start from a sourced two-stage example</h2>
+        <p>
+          The default stack uses Falcon 9 Full Thrust stage numbers from issue #24’s advisory
+          comment so this page stays educational without inventing extra aerospace data.
+        </p>
+      </section>
+
+      <section aria-labelledby="designer-controls-title">
+        <div class="designer-toolbar">
+          <div>
+            <h2 id="designer-controls-title">Vehicle inputs</h2>
+            <p class="muted">
+              Use 1 to 6 stages. Inputs update the outputs, capability label, and chart on every
+              change.
+            </p>
+          </div>
+
+          <div class="designer-toolbar-actions" aria-label="Stage count controls">
+            <button type="button" id="remove-stage">Remove stage</button>
+            <p id="stage-count" class="stage-count" aria-live="polite">2 stages</p>
+            <button type="button" id="add-stage">Add stage</button>
+          </div>
+        </div>
+
+        <form id="designer-form" novalidate>
+          <p id="designer-error" class="callout callout-danger" role="alert" aria-live="polite" hidden></p>
+          <div id="stage-list" class="stage-list"></div>
+        </form>
+      </section>
+
+      <section aria-labelledby="designer-results-title">
+        <h2 id="designer-results-title">Live stack results</h2>
+
+        <div class="summary-grid">
+          <article class="summary-card">
+            <h3>Total stack Δv</h3>
+            <p id="total-dv" class="summary-value" aria-live="polite">—</p>
+          </article>
+
+          <article class="summary-card">
+            <h3>Capability label</h3>
+            <p id="capability-label" class="summary-value" aria-live="polite">—</p>
+          </article>
+
+          <article class="summary-card">
+            <h3>Chart status</h3>
+            <p id="chart-status-summary" class="summary-value" aria-live="polite">Ready</p>
+          </article>
+        </div>
+
+        <p id="twr-warning" class="callout callout-warning" role="alert" aria-live="polite" hidden></p>
+      </section>
+
+      <section aria-labelledby="chart-title">
+        <h2 id="chart-title">Velocity vs burned propellant fraction</h2>
+        <p class="muted">
+          The chart shows how cumulative ideal Δv grows as each stage burns through its propellant.
+        </p>
+
+        <figure class="chart-figure">
+          <svg
+            id="velocity-chart"
+            class="velocity-chart"
+            viewBox="0 0 720 420"
+            role="img"
+            aria-labelledby="chart-svg-title chart-svg-desc"
+          >
+            <title id="chart-svg-title">Velocity gain versus burned propellant fraction</title>
+            <desc id="chart-svg-desc">
+              A line chart showing cumulative ideal delta-v as the rocket burns propellant across
+              all stages.
+            </desc>
+          </svg>
+          <figcaption id="chart-caption">
+            X-axis: burned propellant fraction. Y-axis: cumulative ideal Δv in meters per second.
+          </figcaption>
+        </figure>
+
+        <p id="chart-error" class="callout callout-danger" aria-live="polite" hidden>
+          Fix the highlighted inputs to restore the chart.
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <small>
+        Multi-stage designer powered by <code>docs/lib/rocket.js</code> ·
+        <a href="./index.html">Back to the equation guide</a>
+      </small>
+    </footer>
+  </body>
+</html>

--- a/docs/designer.js
+++ b/docs/designer.js
@@ -1,0 +1,585 @@
+import {
+  capabilityLabel,
+  initialTWR,
+  stackDeltaV,
+  stageDeltaV,
+  validateStage,
+} from './lib/rocket.js';
+
+const MIN_STAGES = 1;
+const MAX_STAGES = 6;
+const CHART_STEPS_PER_STAGE = 20;
+
+const numberFmt = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+});
+
+const twrFmt = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const defaultStageTemplates = [
+  // Falcon 9 FT-like defaults from issue #24 advisory comment:
+  // https://github.com/chkap/rocket-edu-mvp/issues/24#issuecomment-4286980437
+  { m_p: '410900', m_s: '22200', Isp: '282', thrust_kN: '7607' },
+  { m_p: '107500', m_s: '4000', Isp: '348', thrust_kN: '934' },
+];
+
+const state = {
+  stages: defaultStageTemplates.map((stage) => ({ ...stage })),
+  finalPayload: '0',
+};
+
+function cloneStageTemplate(index) {
+  const template =
+    state.stages[state.stages.length - 1] ??
+    defaultStageTemplates[index] ??
+    defaultStageTemplates[defaultStageTemplates.length - 1];
+  return { ...template };
+}
+
+function stageLabel(index, total) {
+  if (total === 1) {
+    return 'Single stage';
+  }
+
+  return `Stage ${index + 1}`;
+}
+
+function stageRoleLabel(index, total) {
+  if (total === 1) {
+    return 'Top and only stage';
+  }
+
+  if (index === 0) {
+    return 'Bottom stage';
+  }
+
+  if (index === total - 1) {
+    return 'Top stage';
+  }
+
+  return 'Middle stage';
+}
+
+function buildStageMarkup(stage, index, totalStages) {
+  const prefix = `stage-${index}`;
+  const isTopStage = index === totalStages - 1;
+
+  return `
+    <article class="stage-card" aria-labelledby="${prefix}-title">
+      <div class="stage-card-header">
+        <div>
+          <h3 id="${prefix}-title">${stageLabel(index, totalStages)}</h3>
+          <p class="stage-role">${stageRoleLabel(index, totalStages)}</p>
+        </div>
+      </div>
+
+      <div class="form-grid">
+        ${buildInputMarkup({
+          id: `${prefix}-m_p`,
+          name: `stage-${index}-m_p`,
+          label: 'Propellant mass, m_p (kg)',
+          value: stage.m_p,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-m_s`,
+          name: `stage-${index}-m_s`,
+          label: 'Structural mass, m_s (kg)',
+          value: stage.m_s,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-isp`,
+          name: `stage-${index}-Isp`,
+          label: 'Isp (seconds)',
+          value: stage.Isp,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-thrust`,
+          name: `stage-${index}-thrust_kN`,
+          label: 'Thrust (kN)',
+          value: stage.thrust_kN,
+        })}
+        ${
+          isTopStage
+            ? buildInputMarkup({
+                id: 'top-payload',
+                name: 'finalPayload',
+                label: 'Payload above top stage (kg)',
+                value: state.finalPayload,
+              })
+            : ''
+        }
+      </div>
+
+      <div class="stage-metrics" aria-live="polite">
+        <article class="metric-card">
+          <h4>Stage Δv</h4>
+          <p id="${prefix}-dv" class="metric-value">—</p>
+        </article>
+        <article class="metric-card">
+          <h4>Initial TWR</h4>
+          <p id="${prefix}-twr" class="metric-value">—</p>
+        </article>
+      </div>
+    </article>
+  `;
+}
+
+function buildInputMarkup({ id, name, label, value }) {
+  return `
+    <div class="form-field">
+      <label for="${id}">${label}</label>
+      <input
+        id="${id}"
+        name="${name}"
+        type="number"
+        inputmode="decimal"
+        step="any"
+        autocomplete="off"
+        value="${value}"
+        aria-describedby="${id}-error"
+      />
+      <p id="${id}-error" class="field-error" aria-live="polite"></p>
+    </div>
+  `;
+}
+
+function renderStageCards() {
+  const stageList = document.getElementById('stage-list');
+  const stageCount = document.getElementById('stage-count');
+  const addButton = document.getElementById('add-stage');
+  const removeButton = document.getElementById('remove-stage');
+
+  if (!stageList || !stageCount || !addButton || !removeButton) {
+    return;
+  }
+
+  stageList.innerHTML = state.stages
+    .map((stage, index) => buildStageMarkup(stage, index, state.stages.length))
+    .join('');
+
+  stageCount.textContent = `${state.stages.length} ${state.stages.length === 1 ? 'stage' : 'stages'}`;
+  addButton.disabled = state.stages.length >= MAX_STAGES;
+  removeButton.disabled = state.stages.length <= MIN_STAGES;
+}
+
+function syncStateFromInputs() {
+  state.stages = state.stages.map((stage, index) => ({
+    ...stage,
+    m_p: document.getElementById(`stage-${index}-m_p`)?.value ?? stage.m_p,
+    m_s: document.getElementById(`stage-${index}-m_s`)?.value ?? stage.m_s,
+    Isp: document.getElementById(`stage-${index}-isp`)?.value ?? stage.Isp,
+    thrust_kN: document.getElementById(`stage-${index}-thrust`)?.value ?? stage.thrust_kN,
+  }));
+
+  state.finalPayload = document.getElementById('top-payload')?.value ?? state.finalPayload;
+}
+
+function resetFieldErrors() {
+  document
+    .querySelectorAll('#designer-form .field-error')
+    .forEach((el) => {
+      el.textContent = '';
+    });
+
+  document
+    .querySelectorAll('#designer-form input')
+    .forEach((el) => {
+      el.classList.remove('input-invalid');
+      el.removeAttribute('aria-invalid');
+    });
+}
+
+function setFieldError(id, message) {
+  const input = document.getElementById(id);
+  const error = document.getElementById(`${id}-error`);
+
+  if (input) {
+    input.classList.add('input-invalid');
+    input.setAttribute('aria-invalid', 'true');
+  }
+
+  if (error) {
+    error.textContent = message;
+  }
+}
+
+function readPositiveField(rawValue, id, label, errors) {
+  const value = Number(rawValue);
+
+  if (rawValue === '' || !Number.isFinite(value)) {
+    errors.push({ id, message: `${label} must be a finite number.` });
+    return null;
+  }
+
+  if (value <= 0) {
+    errors.push({ id, message: `${label} must be greater than 0.` });
+    return null;
+  }
+
+  return value;
+}
+
+function readNonNegativeField(rawValue, id, label, errors) {
+  const value = Number(rawValue);
+
+  if (rawValue === '' || !Number.isFinite(value)) {
+    errors.push({ id, message: `${label} must be a finite number.` });
+    return null;
+  }
+
+  if (value < 0) {
+    errors.push({ id, message: `${label} must be greater than or equal to 0.` });
+    return null;
+  }
+
+  return value;
+}
+
+function parseState() {
+  const errors = [];
+
+  const stages = state.stages.map((stage, index) => ({
+    m_p: readPositiveField(stage.m_p, `stage-${index}-m_p`, 'Propellant mass', errors),
+    m_s: readPositiveField(stage.m_s, `stage-${index}-m_s`, 'Structural mass', errors),
+    Isp: readPositiveField(stage.Isp, `stage-${index}-isp`, 'Isp', errors),
+    thrust_kN: readPositiveField(stage.thrust_kN, `stage-${index}-thrust`, 'Thrust', errors),
+  }));
+
+  const finalPayload = readNonNegativeField(
+    state.finalPayload,
+    'top-payload',
+    'Payload',
+    errors
+  );
+
+  if (errors.length === 0) {
+    stages.forEach((stage) => validateStage(stage));
+  }
+
+  return { stages, finalPayload, errors };
+}
+
+function computePayloadMasses(stages, finalPayload) {
+  const payloadMasses = new Array(stages.length);
+  let payload = finalPayload;
+
+  for (let index = stages.length - 1; index >= 0; index -= 1) {
+    payloadMasses[index] = payload;
+    payload += stages[index].m_p + stages[index].m_s;
+  }
+
+  return payloadMasses;
+}
+
+function buildChartData(stages, payloadMasses) {
+  const totalPropellant = stages.reduce((sum, stage) => sum + stage.m_p, 0);
+  const points = [{ fraction: 0, deltaV: 0 }];
+  const boundaries = [];
+  let burnedBefore = 0;
+  let cumulativeDeltaV = 0;
+
+  stages.forEach((stage, index) => {
+    const payload = payloadMasses[index];
+
+    for (let step = 1; step <= CHART_STEPS_PER_STAGE; step += 1) {
+      const burned = (stage.m_p * step) / CHART_STEPS_PER_STAGE;
+      const partialDeltaV = stageDeltaV({
+        m_p: burned,
+        m_s: stage.m_s + stage.m_p - burned,
+        payload,
+        Isp: stage.Isp,
+      });
+
+      points.push({
+        fraction: (burnedBefore + burned) / totalPropellant,
+        deltaV: cumulativeDeltaV + partialDeltaV,
+      });
+    }
+
+    cumulativeDeltaV += stageDeltaV({
+      m_p: stage.m_p,
+      m_s: stage.m_s,
+      payload,
+      Isp: stage.Isp,
+    });
+    burnedBefore += stage.m_p;
+
+    boundaries.push({
+      stage: index + 1,
+      fraction: burnedBefore / totalPropellant,
+    });
+  });
+
+  return { points, boundaries };
+}
+
+function renderMetrics(computation) {
+  const totalDvEl = document.getElementById('total-dv');
+  const capabilityEl = document.getElementById('capability-label');
+  const chartStatusSummary = document.getElementById('chart-status-summary');
+  const twrWarning = document.getElementById('twr-warning');
+
+  if (!totalDvEl || !capabilityEl || !chartStatusSummary || !twrWarning) {
+    return;
+  }
+
+  totalDvEl.textContent = `${numberFmt.format(Math.round(computation.total))} m/s`;
+  capabilityEl.textContent = computation.capability;
+  chartStatusSummary.textContent = 'Ready';
+
+  computation.perStage.forEach((stage, index) => {
+    const dvEl = document.getElementById(`stage-${index}-dv`);
+    const twrEl = document.getElementById(`stage-${index}-twr`);
+
+    if (dvEl) {
+      dvEl.textContent = `${numberFmt.format(Math.round(stage.deltaV))} m/s`;
+    }
+
+    if (twrEl) {
+      twrEl.textContent = twrFmt.format(stage.twr);
+    }
+  });
+
+  if (computation.perStage[0].twr < 1) {
+    twrWarning.textContent =
+      `Warning: Stage 1 initial TWR is ${twrFmt.format(computation.perStage[0].twr)}, so the rocket is underpowered at liftoff.`;
+    twrWarning.hidden = false;
+  } else {
+    twrWarning.textContent = '';
+    twrWarning.hidden = true;
+  }
+}
+
+function renderInvalidState(errors) {
+  const errorEl = document.getElementById('designer-error');
+  const chartStatusSummary = document.getElementById('chart-status-summary');
+  const totalDvEl = document.getElementById('total-dv');
+  const capabilityEl = document.getElementById('capability-label');
+  const twrWarning = document.getElementById('twr-warning');
+  const chartError = document.getElementById('chart-error');
+  const chart = document.getElementById('velocity-chart');
+
+  errors.forEach(({ id, message }) => setFieldError(id, message));
+
+  if (errorEl) {
+    errorEl.textContent = 'Fix the highlighted inputs to update the results and chart.';
+    errorEl.hidden = false;
+  }
+
+  if (chartStatusSummary) {
+    chartStatusSummary.textContent = 'Disabled';
+  }
+
+  if (totalDvEl) {
+    totalDvEl.textContent = '—';
+  }
+
+  if (capabilityEl) {
+    capabilityEl.textContent = '—';
+  }
+
+  if (twrWarning) {
+    twrWarning.hidden = true;
+    twrWarning.textContent = '';
+  }
+
+  state.stages.forEach((_, index) => {
+    const dvEl = document.getElementById(`stage-${index}-dv`);
+    const twrEl = document.getElementById(`stage-${index}-twr`);
+
+    if (dvEl) {
+      dvEl.textContent = '—';
+    }
+
+    if (twrEl) {
+      twrEl.textContent = '—';
+    }
+  });
+
+  if (chart) {
+    chart.innerHTML = '';
+    chart.setAttribute('aria-hidden', 'true');
+  }
+
+  if (chartError) {
+    chartError.hidden = false;
+  }
+}
+
+function renderChart(chartData) {
+  const chart = document.getElementById('velocity-chart');
+  const chartError = document.getElementById('chart-error');
+  const width = 720;
+  const height = 420;
+  const margin = { top: 24, right: 24, bottom: 48, left: 64 };
+
+  if (!chart) {
+    return;
+  }
+
+  if (chartError) {
+    chartError.hidden = true;
+  }
+
+  chart.removeAttribute('aria-hidden');
+
+  const maxDeltaV = Math.max(...chartData.points.map((point) => point.deltaV), 1);
+  const plotWidth = width - margin.left - margin.right;
+  const plotHeight = height - margin.top - margin.bottom;
+
+  const x = (fraction) => margin.left + fraction * plotWidth;
+  const y = (deltaV) => margin.top + plotHeight - (deltaV / maxDeltaV) * plotHeight;
+
+  const linePath = chartData.points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${x(point.fraction)} ${y(point.deltaV)}`)
+    .join(' ');
+
+  const yTicks = 4;
+  const gridLines = Array.from({ length: yTicks + 1 }, (_, tick) => {
+    const value = (maxDeltaV * tick) / yTicks;
+    const yPos = y(value);
+    return `
+      <line class="chart-grid" x1="${margin.left}" y1="${yPos}" x2="${width - margin.right}" y2="${yPos}"></line>
+      <text class="chart-label" x="${margin.left - 12}" y="${yPos + 5}" text-anchor="end">${numberFmt.format(
+        Math.round(value)
+      )}</text>
+    `;
+  }).join('');
+
+  const xTicks = Array.from({ length: 5 }, (_, tick) => {
+    const fraction = tick / 4;
+    const xPos = x(fraction);
+    return `
+      <line class="chart-grid" x1="${xPos}" y1="${margin.top}" x2="${xPos}" y2="${height - margin.bottom}"></line>
+      <text class="chart-label" x="${xPos}" y="${height - margin.bottom + 22}" text-anchor="middle">${(
+        fraction * 100
+      ).toFixed(0)}%</text>
+    `;
+  }).join('');
+
+  const boundaries = chartData.boundaries
+    .map(
+      (boundary) => `
+        <line
+          class="chart-boundary"
+          x1="${x(boundary.fraction)}"
+          y1="${margin.top}"
+          x2="${x(boundary.fraction)}"
+          y2="${height - margin.bottom}"
+        ></line>
+        <text class="chart-stage-label" x="${x(boundary.fraction)}" y="${margin.top + 16}">
+          Stage ${boundary.stage}
+        </text>
+      `
+    )
+    .join('');
+
+  const finalPoint = chartData.points[chartData.points.length - 1];
+
+  chart.innerHTML = `
+    <title id="chart-svg-title">Velocity gain versus burned propellant fraction</title>
+    <desc id="chart-svg-desc">
+      A line chart showing cumulative ideal delta-v as the rocket burns propellant across all
+      stages.
+    </desc>
+    <line class="chart-axis" x1="${margin.left}" y1="${height - margin.bottom}" x2="${width - margin.right}" y2="${height - margin.bottom}"></line>
+    <line class="chart-axis" x1="${margin.left}" y1="${margin.top}" x2="${margin.left}" y2="${height - margin.bottom}"></line>
+    ${gridLines}
+    ${xTicks}
+    ${boundaries}
+    <path class="chart-line" d="${linePath}"></path>
+    <circle class="chart-point" cx="${x(finalPoint.fraction)}" cy="${y(finalPoint.deltaV)}" r="5"></circle>
+    <text class="chart-label" x="${width / 2}" y="${height - 8}" text-anchor="middle">Burned propellant fraction</text>
+    <text class="chart-label" x="18" y="${height / 2}" text-anchor="middle" transform="rotate(-90 18 ${height / 2})">
+      Cumulative ideal Δv (m/s)
+    </text>
+  `;
+}
+
+function updateOutputs() {
+  resetFieldErrors();
+  syncStateFromInputs();
+
+  const errorEl = document.getElementById('designer-error');
+  if (errorEl) {
+    errorEl.hidden = true;
+    errorEl.textContent = '';
+  }
+
+  const parsed = parseState();
+  if (parsed.errors.length > 0 || parsed.finalPayload === null) {
+    renderInvalidState(parsed.errors);
+    return;
+  }
+
+  const payloadMasses = computePayloadMasses(parsed.stages, parsed.finalPayload);
+  const stack = stackDeltaV(parsed.stages, parsed.finalPayload);
+
+  const perStage = parsed.stages.map((stage, index) => ({
+    deltaV: stack.perStage[index],
+    twr: initialTWR({
+      thrust_kN: stage.thrust_kN,
+      totalMassAbove_kg: stage.m_p + stage.m_s + payloadMasses[index],
+    }),
+  }));
+
+  renderMetrics({
+    perStage,
+    total: stack.total,
+    capability: capabilityLabel(stack.total),
+  });
+
+  renderChart(buildChartData(parsed.stages, payloadMasses));
+}
+
+function addStage() {
+  syncStateFromInputs();
+
+  if (state.stages.length >= MAX_STAGES) {
+    return;
+  }
+
+  state.stages.push(cloneStageTemplate(state.stages.length));
+  renderStageCards();
+  updateOutputs();
+}
+
+function removeStage() {
+  syncStateFromInputs();
+
+  if (state.stages.length <= MIN_STAGES) {
+    return;
+  }
+
+  state.stages.pop();
+  renderStageCards();
+  updateOutputs();
+}
+
+function init() {
+  const addButton = document.getElementById('add-stage');
+  const removeButton = document.getElementById('remove-stage');
+  const form = document.getElementById('designer-form');
+
+  if (!addButton || !removeButton || !form) {
+    return;
+  }
+
+  renderStageCards();
+  updateOutputs();
+
+  addButton.addEventListener('click', addStage);
+  removeButton.addEventListener('click', removeStage);
+  form.addEventListener('input', updateOutputs);
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,7 @@
 
       <nav aria-label="Primary">
         <ul>
+          <li><a href="./designer.html">Multi-stage designer</a></li>
           <li><a href="#equation">Equation</a></li>
           <li><a href="#explanation">Explanation</a></li>
           <li><a href="#calculator">Calculator</a></li>


### PR DESCRIPTION
<!-- agent:worker to:verifier type:pr-ready -->

Adds a plain-HTML/CSS/JS multi-stage designer page that imports the shared rocket core, starts from sourced two-stage defaults from issue #24, recomputes stage metrics live, shows inline validation, and renders an SVG velocity chart.

## How to test

1. Run `npm install` from the repository root.
2. Run `npm test`.
3. From `docs/`, run `python3 -m http.server 8000` and open `http://127.0.0.1:8000/designer.html`.
4. Confirm the default page shows numeric per-stage outputs plus a chart.
5. Click **Add stage** and confirm the total Δv changes without reloading.
6. Lower Stage 1 thrust until it becomes very small and confirm the TWR warning appears.
7. Set any `m_p` input to `-1` and confirm the inline error appears and the chart disables without crashing.

Closes #26
