### PR TITLE
[#28] /compare.html — real launcher presets vs computed Δv

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Compare real launch vehicle stage data against rocket-equation calculations and try stage-by-stage what-if sliders."
+    />
+    <title>Launcher compare</title>
+    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./designer.css" />
+    <style>
+      .compare-grid {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preset-select {
+        max-width: 24rem;
+      }
+
+      select,
+      input[type='range'] {
+        width: 100%;
+      }
+
+      select {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 0.55rem 0.65rem;
+        font-size: 1rem;
+        background: var(--surface);
+        color: var(--text);
+      }
+
+      .stage-slider {
+        margin-top: 1rem;
+      }
+
+      .slider-row {
+        display: grid;
+        gap: 0.5rem;
+        align-items: center;
+      }
+
+      .slider-row output {
+        font-weight: 700;
+      }
+
+      .source-list {
+        padding-left: 1.25rem;
+        margin: 0.75rem 0 0;
+      }
+
+      .source-list li + li {
+        margin-top: 0.35rem;
+      }
+
+      .note-list {
+        padding-left: 1.25rem;
+        margin: 0.5rem 0 0;
+      }
+    </style>
+    <script type="module" src="./compare.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Real launcher compare</h1>
+      <p>
+        Start from cited launcher data, compare the ideal stack to a cited mission requirement, and
+        explore how stage-by-stage what-if changes shift the outcome.
+      </p>
+
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="./index.html">Equation guide</a></li>
+          <li><a href="./designer.html">Multi-stage designer</a></li>
+          <li><a href="./compare.html" aria-current="page">Launcher compare</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main id="content" class="compare-grid">
+      <section aria-labelledby="preset-title">
+        <h2 id="preset-title">Choose a launcher preset</h2>
+        <div class="form-field preset-select">
+          <label for="launcher-select">Launcher preset</label>
+          <select id="launcher-select" name="launcher"></select>
+        </div>
+        <p id="availability-note" class="callout callout-warning" hidden></p>
+        <p id="launcher-note" class="muted" aria-live="polite"></p>
+      </section>
+
+      <section aria-labelledby="compare-summary-title">
+        <h2 id="compare-summary-title">Computed vs cited Δv</h2>
+        <div class="summary-grid">
+          <article class="summary-card">
+            <h3>Computed total Δv</h3>
+            <p id="computed-dv" class="summary-value" aria-live="polite">—</p>
+          </article>
+          <article class="summary-card">
+            <h3>Cited mission Δv</h3>
+            <p id="published-dv" class="summary-value" aria-live="polite">—</p>
+            <p id="reference-orbit" class="muted"></p>
+          </article>
+          <article class="summary-card">
+            <h3>% delta</h3>
+            <p id="delta-percent" class="summary-value" aria-live="polite">—</p>
+          </article>
+          <article class="summary-card">
+            <h3>Capability label</h3>
+            <p id="capability-label" class="summary-value" aria-live="polite">—</p>
+          </article>
+        </div>
+      </section>
+
+      <section aria-labelledby="editor-title">
+        <h2 id="editor-title">Launcher editor</h2>
+        <p id="compare-error" class="callout callout-danger" role="alert" aria-live="polite" hidden></p>
+        <form id="compare-form" novalidate>
+          <div id="stage-list" class="stage-list"></div>
+        </form>
+      </section>
+
+      <section aria-labelledby="source-title">
+        <h2 id="source-title">Sources</h2>
+        <p class="muted">Every URL below comes directly from the advisory comment in issue #24.</p>
+        <ul id="source-list" class="source-list"></ul>
+      </section>
+    </main>
+
+    <footer>
+      <small>
+        Compare page powered by <code>docs/lib/rocket.js</code> ·
+        <a href="./designer.html">Open the editable designer</a>
+      </small>
+    </footer>
+  </body>
+</html>

--- a/docs/compare.js
+++ b/docs/compare.js
@@ -1,0 +1,499 @@
+import { LAUNCHERS } from './data/launchers.js';
+import { capabilityLabel, initialTWR, stackDeltaV, validateStage } from './lib/rocket.js';
+
+const numberFmt = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+});
+
+const twrFmt = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentFmt = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+  signDisplay: 'always',
+});
+
+const state = {
+  launchers: LAUNCHERS.map(prepareLauncher),
+  selectedId: LAUNCHERS[0]?.id ?? '',
+  stages: [],
+  payload: '0',
+  ispMultipliers: [],
+};
+
+function prepareLauncher(launcher) {
+  const stages = launcher.stages.map((stage) => ({ ...stage }));
+  const payload = solvePayloadForTarget(stages, launcher.referenceDeltaV);
+
+  return {
+    ...launcher,
+    derivedPayload: payload,
+  };
+}
+
+function solvePayloadForTarget(stages, targetDv) {
+  const zeroPayloadDv = stackDeltaV(stages, 0).total;
+  if (zeroPayloadDv <= targetDv) {
+    return 0;
+  }
+
+  let low = 0;
+  let high = 1;
+
+  while (stackDeltaV(stages, high).total > targetDv) {
+    high *= 2;
+  }
+
+  for (let index = 0; index < 80; index += 1) {
+    const mid = (low + high) / 2;
+
+    if (stackDeltaV(stages, mid).total > targetDv) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+
+  return high;
+}
+
+function getSelectedLauncher() {
+  return state.launchers.find((launcher) => launcher.id === state.selectedId) ?? state.launchers[0];
+}
+
+function resetStateForLauncher() {
+  const launcher = getSelectedLauncher();
+
+  state.stages = launcher.stages.map((stage) => ({
+    name: stage.name,
+    m_p: String(stage.m_p),
+    m_s: String(stage.m_s),
+    Isp: String(stage.Isp),
+    thrust_kN: String(stage.thrust_kN),
+  }));
+  state.payload = String(Math.round(launcher.derivedPayload));
+  state.ispMultipliers = launcher.stages.map(() => 100);
+}
+
+function populatePresetSelect() {
+  const select = document.getElementById('launcher-select');
+  const note = document.getElementById('availability-note');
+
+  if (!select || !note) {
+    return;
+  }
+
+  select.innerHTML = state.launchers
+    .map(
+      (launcher) => `
+        <option value="${launcher.id}">${launcher.name}</option>
+      `
+    )
+    .join('');
+
+  const missing = [];
+  note.hidden = missing.length === 0;
+  note.textContent =
+    missing.length === 0
+      ? ''
+      : `Awaiting advisory data for: ${missing.join(', ')}.`;
+}
+
+function buildInputMarkup({ id, name, label, value }) {
+  return `
+    <div class="form-field">
+      <label for="${id}">${label}</label>
+      <input
+        id="${id}"
+        name="${name}"
+        type="number"
+        inputmode="decimal"
+        step="any"
+        autocomplete="off"
+        value="${value}"
+        aria-describedby="${id}-error"
+      />
+      <p id="${id}-error" class="field-error" aria-live="polite"></p>
+    </div>
+  `;
+}
+
+function buildStageMarkup(stage, index, totalStages) {
+  const prefix = `compare-stage-${index}`;
+  const isTopStage = index === totalStages - 1;
+  const multiplier = state.ispMultipliers[index];
+
+  return `
+    <article class="stage-card" aria-labelledby="${prefix}-title">
+      <div class="stage-card-header">
+        <div>
+          <h3 id="${prefix}-title">${stage.name}</h3>
+          <p class="stage-role">${isTopStage ? 'Top stage' : `Stage ${index + 1}`}</p>
+        </div>
+      </div>
+
+      <div class="form-grid">
+        ${buildInputMarkup({
+          id: `${prefix}-m_p`,
+          name: `stage-${index}-m_p`,
+          label: 'Propellant mass, m_p (kg)',
+          value: stage.m_p,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-m_s`,
+          name: `stage-${index}-m_s`,
+          label: 'Structural mass, m_s (kg)',
+          value: stage.m_s,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-isp`,
+          name: `stage-${index}-Isp`,
+          label: 'Isp (seconds)',
+          value: stage.Isp,
+        })}
+        ${buildInputMarkup({
+          id: `${prefix}-thrust`,
+          name: `stage-${index}-thrust_kN`,
+          label: 'Thrust (kN)',
+          value: stage.thrust_kN,
+        })}
+        ${
+          isTopStage
+            ? buildInputMarkup({
+                id: 'compare-payload',
+                name: 'payload',
+                label: 'Payload for cited mission (kg)',
+                value: state.payload,
+              })
+            : ''
+        }
+      </div>
+
+      <div class="stage-slider">
+        <div class="slider-row">
+          <label for="${prefix}-slider">What-if Isp slider</label>
+          <input
+            id="${prefix}-slider"
+            name="slider-${index}"
+            type="range"
+            min="85"
+            max="115"
+            step="1"
+            value="${multiplier}"
+          />
+          <output for="${prefix}-slider" id="${prefix}-slider-output">${multiplier}% of entered Isp</output>
+        </div>
+      </div>
+
+      <div class="stage-metrics" aria-live="polite">
+        <article class="metric-card">
+          <h4>Stage Δv</h4>
+          <p id="${prefix}-dv" class="metric-value">—</p>
+        </article>
+        <article class="metric-card">
+          <h4>Initial TWR</h4>
+          <p id="${prefix}-twr" class="metric-value">—</p>
+        </article>
+      </div>
+    </article>
+  `;
+}
+
+function renderStageCards() {
+  const stageList = document.getElementById('stage-list');
+  if (!stageList) {
+    return;
+  }
+
+  stageList.innerHTML = state.stages
+    .map((stage, index) => buildStageMarkup(stage, index, state.stages.length))
+    .join('');
+}
+
+function syncStateFromInputs() {
+  state.stages = state.stages.map((stage, index) => ({
+    ...stage,
+    m_p: document.getElementById(`compare-stage-${index}-m_p`)?.value ?? stage.m_p,
+    m_s: document.getElementById(`compare-stage-${index}-m_s`)?.value ?? stage.m_s,
+    Isp: document.getElementById(`compare-stage-${index}-isp`)?.value ?? stage.Isp,
+    thrust_kN: document.getElementById(`compare-stage-${index}-thrust`)?.value ?? stage.thrust_kN,
+  }));
+
+  state.payload = document.getElementById('compare-payload')?.value ?? state.payload;
+  state.ispMultipliers = state.ispMultipliers.map(
+    (_, index) => Number(document.getElementById(`compare-stage-${index}-slider`)?.value ?? 100)
+  );
+}
+
+function resetFieldErrors() {
+  document.querySelectorAll('#compare-form .field-error').forEach((el) => {
+    el.textContent = '';
+  });
+
+  document.querySelectorAll('#compare-form input').forEach((el) => {
+    el.classList.remove('input-invalid');
+    el.removeAttribute('aria-invalid');
+  });
+}
+
+function setFieldError(id, message) {
+  const input = document.getElementById(id);
+  const error = document.getElementById(`${id}-error`);
+
+  if (input) {
+    input.classList.add('input-invalid');
+    input.setAttribute('aria-invalid', 'true');
+  }
+
+  if (error) {
+    error.textContent = message;
+  }
+}
+
+function readPositiveField(rawValue, id, label, errors) {
+  const value = Number(rawValue);
+
+  if (rawValue === '' || !Number.isFinite(value)) {
+    errors.push({ id, message: `${label} must be a finite number.` });
+    return null;
+  }
+
+  if (value <= 0) {
+    errors.push({ id, message: `${label} must be greater than 0.` });
+    return null;
+  }
+
+  return value;
+}
+
+function readNonNegativeField(rawValue, id, label, errors) {
+  const value = Number(rawValue);
+
+  if (rawValue === '' || !Number.isFinite(value)) {
+    errors.push({ id, message: `${label} must be a finite number.` });
+    return null;
+  }
+
+  if (value < 0) {
+    errors.push({ id, message: `${label} must be greater than or equal to 0.` });
+    return null;
+  }
+
+  return value;
+}
+
+function parseState() {
+  const errors = [];
+
+  const stages = state.stages.map((stage, index) => {
+    const baseIsp = readPositiveField(stage.Isp, `compare-stage-${index}-isp`, 'Isp', errors);
+    const multiplier = state.ispMultipliers[index] / 100;
+
+    return {
+      name: stage.name,
+      m_p: readPositiveField(
+        stage.m_p,
+        `compare-stage-${index}-m_p`,
+        'Propellant mass',
+        errors
+      ),
+      m_s: readPositiveField(
+        stage.m_s,
+        `compare-stage-${index}-m_s`,
+        'Structural mass',
+        errors
+      ),
+      Isp: baseIsp === null ? null : baseIsp * multiplier,
+      thrust_kN: readPositiveField(
+        stage.thrust_kN,
+        `compare-stage-${index}-thrust`,
+        'Thrust',
+        errors
+      ),
+    };
+  });
+
+  const payload = readNonNegativeField(state.payload, 'compare-payload', 'Payload', errors);
+
+  if (errors.length === 0) {
+    stages.forEach((stage) => validateStage(stage));
+  }
+
+  return { stages, payload, errors };
+}
+
+function computePayloadMasses(stages, payload) {
+  const payloadMasses = new Array(stages.length);
+  let runningPayload = payload;
+
+  for (let index = stages.length - 1; index >= 0; index -= 1) {
+    payloadMasses[index] = runningPayload;
+    runningPayload += stages[index].m_p + stages[index].m_s;
+  }
+
+  return payloadMasses;
+}
+
+function renderInvalidState(errors) {
+  const errorEl = document.getElementById('compare-error');
+  const metricIds = ['computed-dv', 'delta-percent', 'capability-label'];
+
+  errors.forEach(({ id, message }) => setFieldError(id, message));
+
+  if (errorEl) {
+    errorEl.hidden = false;
+    errorEl.textContent = 'Fix the highlighted inputs to recompute the launcher comparison.';
+  }
+
+  metricIds.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.textContent = '—';
+    }
+  });
+
+  state.stages.forEach((_, index) => {
+    const dvEl = document.getElementById(`compare-stage-${index}-dv`);
+    const twrEl = document.getElementById(`compare-stage-${index}-twr`);
+    const outputEl = document.getElementById(`compare-stage-${index}-slider-output`);
+
+    if (dvEl) {
+      dvEl.textContent = '—';
+    }
+
+    if (twrEl) {
+      twrEl.textContent = '—';
+    }
+
+    if (outputEl) {
+      outputEl.textContent = `${state.ispMultipliers[index]}% of entered Isp`;
+    }
+  });
+}
+
+function renderSummary(launcher, totalDv) {
+  const computedDvEl = document.getElementById('computed-dv');
+  const publishedDvEl = document.getElementById('published-dv');
+  const deltaPercentEl = document.getElementById('delta-percent');
+  const capabilityEl = document.getElementById('capability-label');
+  const orbitEl = document.getElementById('reference-orbit');
+  const noteEl = document.getElementById('launcher-note');
+
+  if (!computedDvEl || !publishedDvEl || !deltaPercentEl || !capabilityEl || !orbitEl || !noteEl) {
+    return;
+  }
+
+  const deltaPercent = ((totalDv - launcher.referenceDeltaV) / launcher.referenceDeltaV) * 100;
+
+  computedDvEl.textContent = `${numberFmt.format(Math.round(totalDv))} m/s`;
+  publishedDvEl.textContent = `${numberFmt.format(Math.round(launcher.referenceDeltaV))} m/s`;
+  deltaPercentEl.textContent = percentFmt.format(deltaPercent);
+  capabilityEl.textContent = capabilityLabel(totalDv);
+  orbitEl.textContent = launcher.referenceOrbit;
+  noteEl.textContent = `${launcher.notes} The payload field is derived at runtime from the cited mission Δv and the sourced stage numbers, so slider and input changes can move it away from the reference comparison.`;
+}
+
+function renderStageMetrics(stages, payloadMasses, stack) {
+  stages.forEach((stage, index) => {
+    const dvEl = document.getElementById(`compare-stage-${index}-dv`);
+    const twrEl = document.getElementById(`compare-stage-${index}-twr`);
+    const outputEl = document.getElementById(`compare-stage-${index}-slider-output`);
+
+    if (dvEl) {
+      dvEl.textContent = `${numberFmt.format(Math.round(stack.perStage[index]))} m/s`;
+    }
+
+    if (twrEl) {
+      twrEl.textContent = twrFmt.format(
+        initialTWR({
+          thrust_kN: stage.thrust_kN,
+          totalMassAbove_kg: stage.m_p + stage.m_s + payloadMasses[index],
+        })
+      );
+    }
+
+    if (outputEl) {
+      outputEl.textContent = `${state.ispMultipliers[index]}% of entered Isp`;
+    }
+  });
+}
+
+function renderSources() {
+  const sourceList = document.getElementById('source-list');
+  if (!sourceList) {
+    return;
+  }
+
+  const urls = Array.from(
+    new Set(state.launchers.flatMap((launcher) => launcher.sourceUrls))
+  );
+
+  sourceList.innerHTML = urls
+    .map(
+      (url) => `
+        <li><a href="${url}" target="_blank" rel="noreferrer">${url}</a></li>
+      `
+    )
+    .join('');
+}
+
+function updateOutputs() {
+  resetFieldErrors();
+  syncStateFromInputs();
+
+  const errorEl = document.getElementById('compare-error');
+  if (errorEl) {
+    errorEl.hidden = true;
+    errorEl.textContent = '';
+  }
+
+  const parsed = parseState();
+  if (parsed.errors.length > 0 || parsed.payload === null) {
+    renderInvalidState(parsed.errors);
+    return;
+  }
+
+  const launcher = getSelectedLauncher();
+  const payloadMasses = computePayloadMasses(parsed.stages, parsed.payload);
+  const stack = stackDeltaV(parsed.stages, parsed.payload);
+
+  renderSummary(launcher, stack.total);
+  renderStageMetrics(parsed.stages, payloadMasses, stack);
+}
+
+function handlePresetChange(event) {
+  state.selectedId = event.target.value;
+  resetStateForLauncher();
+  renderStageCards();
+  updateOutputs();
+}
+
+function init() {
+  const select = document.getElementById('launcher-select');
+  const form = document.getElementById('compare-form');
+
+  if (!select || !form || state.launchers.length === 0) {
+    return;
+  }
+
+  populatePresetSelect();
+  select.value = state.selectedId;
+  resetStateForLauncher();
+  renderStageCards();
+  renderSources();
+  updateOutputs();
+
+  select.addEventListener('change', handlePresetChange);
+  form.addEventListener('input', updateOutputs);
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}

--- a/docs/data/launchers.js
+++ b/docs/data/launchers.js
@@ -1,0 +1,141 @@
+export const LAUNCHERS = [
+  {
+    id: 'falcon9-v12-expendable',
+    name: 'Falcon 9 v1.2 expendable',
+    referenceOrbit: 'Surface to GTO requirement',
+    referenceDeltaV: 12100, // Surface→GTO requirement source: issue #24 advisory comment
+    notes:
+      'Issue #24 notes that SpaceX does not publish a single total mission Δv, so this preset compares the ideal stack to the cited surface-to-GTO requirement.',
+    sourceUrls: [
+      'https://en.wikipedia.org/wiki/Falcon_9_Full_Thrust',
+      'https://en.wikipedia.org/wiki/Merlin_1D',
+      'https://mail.gis.byu.edu/rockets/physics/delta-v',
+      'https://ocw.mit.edu/courses/16-07-dynamics-fall-2009/e6393974ce4ed22b095f2e1d1a6a8e81_MIT16_07F09_Lec17.pdf',
+    ],
+    stages: [
+      {
+        name: 'Stage 1',
+        m_p: 410900, // m_p source: issue #24 advisory comment
+        m_s: 22200, // m_s source: issue #24 advisory comment
+        Isp: 282, // Isp source: issue #24 advisory comment
+        thrust_kN: 7607, // thrust_kN source: issue #24 advisory comment
+      },
+      {
+        name: 'Stage 2',
+        m_p: 107500, // m_p source: issue #24 advisory comment
+        m_s: 4000, // m_s source: issue #24 advisory comment
+        Isp: 348, // Isp source: issue #24 advisory comment
+        thrust_kN: 934, // thrust_kN source: issue #24 advisory comment
+      },
+    ],
+  },
+  {
+    id: 'saturn-v',
+    name: 'Saturn V',
+    referenceOrbit: 'Surface to TLI requirement',
+    referenceDeltaV: 12800, // Surface→TLI requirement source: issue #24 advisory comment
+    notes:
+      'Issue #24 recommends comparing Saturn V to the cited TLI requirement assembled from the BYU and ESA sources.',
+    sourceUrls: [
+      'https://en.wikipedia.org/wiki/S-IC',
+      'https://en.wikipedia.org/wiki/S-II',
+      'https://en.wikipedia.org/wiki/S-IVB',
+      'https://mail.gis.byu.edu/rockets/physics/delta-v',
+      'https://www.esa.int/esapub/bulletin/bullet103/biesbroek103.pdf',
+    ],
+    stages: [
+      {
+        name: 'S-IC',
+        m_p: 2077000, // m_p source: issue #24 advisory comment
+        m_s: 137000, // m_s source: issue #24 advisory comment
+        Isp: 263, // Isp source: issue #24 advisory comment
+        thrust_kN: 34500, // thrust_kN source: issue #24 advisory comment
+      },
+      {
+        name: 'S-II',
+        m_p: 443000, // m_p source: issue #24 advisory comment
+        m_s: 36200, // m_s source: issue #24 advisory comment
+        Isp: 421, // Isp source: issue #24 advisory comment
+        thrust_kN: 4400, // thrust_kN source: issue #24 advisory comment
+      },
+      {
+        name: 'S-IVB',
+        m_p: 109500, // m_p source: issue #24 advisory comment
+        m_s: 13500, // m_s source: issue #24 advisory comment
+        Isp: 421, // Isp source: issue #24 advisory comment
+        thrust_kN: 1033.1, // thrust_kN source: issue #24 advisory comment
+      },
+    ],
+  },
+  {
+    id: 'long-march-5',
+    name: 'Long March 5',
+    referenceOrbit: 'Surface to GTO requirement',
+    referenceDeltaV: 12100, // Surface→GTO requirement source: issue #24 advisory comment
+    notes:
+      'Issue #24 recommends modeling the four boosters in parallel with the core; this MVP serializes them as a first stage while keeping the cited stage numbers unchanged.',
+    sourceUrls: [
+      'https://en.wikipedia.org/wiki/Long_March_5',
+      'https://mail.gis.byu.edu/rockets/physics/delta-v',
+      'https://ocw.mit.edu/courses/16-07-dynamics-fall-2009/e6393974ce4ed22b095f2e1d1a6a8e81_MIT16_07F09_Lec17.pdf',
+    ],
+    stages: [
+      {
+        name: 'Boosters (4x CZ-5-300, serialized)',
+        m_p: 571200, // 4 × booster m_p source: issue #24 advisory comment
+        m_s: 55200, // 4 × booster m_s source: issue #24 advisory comment
+        Isp: 300, // booster sea-level Isp source: issue #24 advisory comment
+        thrust_kN: 9600, // 4 × booster sea-level thrust source: issue #24 advisory comment
+      },
+      {
+        name: 'Core stage',
+        m_p: 165300, // m_p source: issue #24 advisory comment
+        m_s: 21600, // m_s source: issue #24 advisory comment
+        Isp: 316.7, // Isp source: issue #24 advisory comment
+        thrust_kN: 1036, // thrust_kN source: issue #24 advisory comment
+      },
+      {
+        name: 'Upper stage',
+        m_p: 29100, // m_p source: issue #24 advisory comment
+        m_s: 5100, // m_s source: issue #24 advisory comment
+        Isp: 442.6, // Isp source: issue #24 advisory comment
+        thrust_kN: 176.72, // thrust_kN source: issue #24 advisory comment
+      },
+    ],
+  },
+  {
+    id: 'soyuz-21b',
+    name: 'Soyuz-2.1b',
+    referenceOrbit: 'Surface to LEO requirement',
+    referenceDeltaV: 9700, // Surface→LEO requirement source: issue #24 advisory comment
+    notes:
+      'Issue #24 recommends modeling the four boosters in parallel with the core; this MVP serializes them as a first stage while preserving the cited per-stage values.',
+    sourceUrls: [
+      'https://en.wikipedia.org/wiki/Soyuz-2',
+      'https://mail.gis.byu.edu/rockets/physics/delta-v',
+    ],
+    stages: [
+      {
+        name: 'Boosters (4x Block B/V/G/D, serialized)',
+        m_p: 156640, // 4 × booster m_p source: issue #24 advisory comment
+        m_s: 15136, // 4 × booster m_s source: issue #24 advisory comment
+        Isp: 262, // booster sea-level Isp source: issue #24 advisory comment
+        thrust_kN: 3354, // 4 × booster sea-level thrust source: issue #24 advisory comment
+      },
+      {
+        name: 'Core stage',
+        m_p: 90100, // m_p source: issue #24 advisory comment
+        m_s: 6545, // m_s source: issue #24 advisory comment
+        Isp: 255, // Isp source: issue #24 advisory comment
+        thrust_kN: 792.5, // thrust_kN source: issue #24 advisory comment
+      },
+      {
+        name: 'Block I',
+        m_p: 25400, // m_p source: issue #24 advisory comment
+        m_s: 2355, // m_s source: issue #24 advisory comment
+        Isp: 359, // Isp source: issue #24 advisory comment
+        thrust_kN: 294.3, // thrust_kN source: issue #24 advisory comment
+      },
+    ],
+  },
+];

--- a/docs/designer.html
+++ b/docs/designer.html
@@ -24,6 +24,7 @@
         <ul>
           <li><a href="./index.html">Equation guide</a></li>
           <li><a href="./designer.html" aria-current="page">Multi-stage designer</a></li>
+          <li><a href="./compare.html">Launcher compare</a></li>
         </ul>
       </nav>
     </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,7 @@
       <nav aria-label="Primary">
         <ul>
           <li><a href="./designer.html">Multi-stage designer</a></li>
+          <li><a href="./compare.html">Launcher compare</a></li>
           <li><a href="#equation">Equation</a></li>
           <li><a href="#explanation">Explanation</a></li>
           <li><a href="#calculator">Calculator</a></li>


### PR DESCRIPTION
<!-- agent:worker to:verifier type:pr-ready -->

Adds `/compare.html` with cited launcher presets from issue #24, a designer-style multi-stage editor, derived reference payloads that line up the ideal stack with the cited mission target, live what-if Isp sliders, and source URLs in the footer.

## How to test

1. Run `npm install` from the repository root.
2. Run `npm test`.
3. From `docs/`, run `python3 -m http.server 8000` and open `http://127.0.0.1:8000/compare.html`.
4. Confirm all 4 presets are selectable and each shows computed Δv, cited Δv, percent delta, and a capability label.
5. Move a stage slider and confirm the computed Δv and capability label update live.
6. Verify the footer source URLs match the advisory comment in issue #24.
7. Inspect `docs/data/launchers.js` and confirm every numeric field has an inline `issue #24 advisory comment` source note.

Closes #28
