### PR TITLE
[#27] CI workflow (vitest + Lighthouse a11y ≥ 90) + README update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npm test
+
+  a11y:
+    name: a11y
+    runs-on: ubuntu-latest
+    needs: unit-tests
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lighthouse accessibility checks
+        run: |
+          npx --yes http-server docs -p 8080 >/tmp/http-server.log 2>&1 &
+          SERVER_PID=$!
+          cleanup() {
+            kill "$SERVER_PID"
+          }
+          trap cleanup EXIT
+
+          cat > lighthouserc.json <<'EOF'
+          {
+            "ci": {
+              "collect": {
+                "url": [
+                  "http://127.0.0.1:8080/designer.html",
+                  "http://127.0.0.1:8080/compare.html"
+                ],
+                "numberOfRuns": 1
+              },
+              "assert": {
+                "assertions": {
+                  "categories:accessibility": [
+                    "error",
+                    {
+                      "minScore": 0.9
+                    }
+                  ]
+                }
+              }
+            }
+          }
+          EOF
+
+          npx --yes wait-on http://127.0.0.1:8080/designer.html http://127.0.0.1:8080/compare.html
+          npx --yes @lhci/cli@0.15.1 autorun --config=lighthouserc.json

--- a/README.md
+++ b/README.md
@@ -6,8 +6,37 @@ of four AI agents that coordinate exclusively through GitHub issues and PRs.
 
 > Δv = Isp · g₀ · ln(m₀ / m_f)
 
-The finished site lives in [`site/`](./site) and is intended to deploy to
-GitHub Pages with no build step (one HTML file + a little CSS/JS).
+The finished site lives in [`docs/`](./docs) and is intended to deploy to
+GitHub Pages with no build step (plain HTML, CSS, and JavaScript files).
+
+## Features
+
+- **Δv calculator** for the Tsiolkovsky rocket equation, with validation and a
+  worked Falcon 9 example.
+- **Multi-stage designer** for live per-stage Δv, TWR, capability labels, and
+  a stage-burn velocity chart.
+- **Real-mission compare** for cited launcher presets versus computed ideal Δv.
+
+## Sources
+
+- [Issue #23 advisory comment](https://github.com/chkap/rocket-edu-mvp/issues/23#issuecomment-4286980274)
+  — Δv budget thresholds and capability-label assumptions.
+- [Issue #24 advisory comment](https://github.com/chkap/rocket-edu-mvp/issues/24#issuecomment-4286980437)
+  — launcher stage masses, Isp, thrust, and mission-reference comparisons.
+
+## Development
+
+```bash
+npm install
+npm test
+```
+
+To preview the static site locally:
+
+```bash
+cd docs
+python3 -m http.server
+```
 
 ## The 4-role agent crew
 
@@ -68,7 +97,7 @@ README.md
   tick.sh
   setup-labels.sh
   prompts/{lead,worker,verifier,advisory}.md
-site/                 # the website itself (built by the Worker)
+docs/                 # the website itself (built by the Worker)
 ```
 
 ## Status


### PR DESCRIPTION
<!-- agent:worker to:verifier type:pr-ready -->

Adds a GitHub Actions CI workflow with separate `unit-tests` and `a11y` jobs, runs Lighthouse accessibility assertions against the new docs pages, and updates the README with current features, sources, development commands, and the correct `docs/` site location.

## How to test

1. Run `npm install` from the repository root.
2. Run `npm test`.
3. Inspect `.github/workflows/ci.yml` to confirm `pull_request` and `push` to `main`, the `unit-tests` job (`npm ci`, `npm test`), and the `a11y` job for `/designer.html` and `/compare.html` with a 0.9 accessibility minimum.
4. Inspect `README.md` to confirm the Features, Sources, and Development sections and the advisory links for issues #23 and #24.
5. On GitHub, confirm the PR shows both `unit-tests` and `a11y` checks after Actions runs.

Closes #27
