### PR TITLE
Add Rocket Designer v2 physics module

### DIFF
--- a/docs/data/engines.json
+++ b/docs/data/engines.json
@@ -1,0 +1,208 @@
+{
+  "g0": 9.80665,
+  "engines": [
+    {
+      "key": "merlin_1d",
+      "thrust_sl_kN": 845,
+      "thrust_vac_kN": 981,
+      "isp_sl": 282,
+      "isp_vac": 311,
+      "mass_kg": 470,
+      "propellant": "RP1_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/SpaceX_Merlin"]
+    },
+    {
+      "key": "merlin_vac",
+      "thrust_sl_kN": 0,
+      "thrust_vac_kN": 934,
+      "isp_sl": 0,
+      "isp_vac": 348,
+      "mass_kg": 550,
+      "propellant": "RP1_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": [
+        "https://en.wikipedia.org/wiki/Falcon_9_Full_Thrust",
+        "http://www.astronautix.com/m/merlin1dvac.html"
+      ]
+    },
+    {
+      "key": "raptor_2",
+      "thrust_sl_kN": 2260,
+      "thrust_vac_kN": 2530,
+      "isp_sl": 327,
+      "isp_vac": 350,
+      "mass_kg": 1630,
+      "propellant": "CH4_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/SpaceX_Raptor"]
+    },
+    {
+      "key": "raptor_vac",
+      "thrust_sl_kN": 0,
+      "thrust_vac_kN": 2530,
+      "isp_sl": 0,
+      "isp_vac": 380,
+      "mass_kg": 1900,
+      "propellant": "CH4_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_decision_source": "https://github.com/chkap/rocket-edu-mvp/issues/35#issuecomment-4289967660",
+      "_citations": ["https://en.wikipedia.org/wiki/SpaceX_Raptor"],
+      "_assumption": "GOAL.md value for dry mass; Advisory could not find a cited public source."
+    },
+    {
+      "key": "rs25",
+      "thrust_sl_kN": 1860,
+      "thrust_vac_kN": 2279,
+      "isp_sl": 366,
+      "isp_vac": 452.3,
+      "mass_kg": 3177,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/RS-25"]
+    },
+    {
+      "key": "f1",
+      "thrust_sl_kN": 6770,
+      "thrust_vac_kN": 7770,
+      "isp_sl": 263,
+      "isp_vac": 304,
+      "mass_kg": 8400,
+      "propellant": "RP1_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/Rocketdyne_F-1"]
+    },
+    {
+      "key": "rl10b2",
+      "thrust_sl_kN": 0,
+      "thrust_vac_kN": 110.1,
+      "isp_sl": 0,
+      "isp_vac": 465.5,
+      "mass_kg": 301,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/RL10"]
+    },
+    {
+      "key": "vulcain2",
+      "thrust_sl_kN": 939.5,
+      "thrust_vac_kN": 1350,
+      "isp_sl": 318,
+      "isp_vac": 434,
+      "mass_kg": 1800,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["http://www.astronautix.com/v/vulcain2.html"]
+    },
+    {
+      "key": "be4",
+      "thrust_sl_kN": 2400,
+      "thrust_vac_kN": 2640,
+      "isp_sl": 311,
+      "isp_vac": 340,
+      "mass_kg": 5400,
+      "propellant": "CH4_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_decision_source": "https://github.com/chkap/rocket-edu-mvp/issues/35#issuecomment-4289967660",
+      "_citations": [
+        "https://en.wikipedia.org/wiki/BE-4",
+        "https://www.ulalaunch.com/docs/default-source/news-items/be-4_fact_sheet_web_final_2.pdf"
+      ],
+      "_assumption": "Thrust values follow GOAL.md; Isp and mass follow Advisory guidance from the public BE-4 references."
+    },
+    {
+      "key": "nk33",
+      "thrust_sl_kN": 1510,
+      "thrust_vac_kN": 1680,
+      "isp_sl": 297,
+      "isp_vac": 331,
+      "mass_kg": 1240,
+      "propellant": "RP1_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/NK-33"]
+    },
+    {
+      "key": "rd180",
+      "thrust_sl_kN": 3830,
+      "thrust_vac_kN": 4150,
+      "isp_sl": 311,
+      "isp_vac": 338,
+      "mass_kg": 5480,
+      "propellant": "RP1_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/RD-180"]
+    },
+    {
+      "key": "j2",
+      "thrust_sl_kN": 486.2,
+      "thrust_vac_kN": 1033.1,
+      "isp_sl": 200,
+      "isp_vac": 421,
+      "mass_kg": 1788.1,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/Rocketdyne_J-2"]
+    },
+    {
+      "key": "yf77",
+      "thrust_sl_kN": 510,
+      "thrust_vac_kN": 700,
+      "isp_sl": 310,
+      "isp_vac": 430,
+      "mass_kg": 2700,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": [
+        "http://astronautix.com/y/yf-77.html",
+        "https://en.wikipedia.org/wiki/YF-77"
+      ]
+    },
+    {
+      "key": "yf75d",
+      "thrust_sl_kN": 0,
+      "thrust_vac_kN": 88.36,
+      "isp_sl": 0,
+      "isp_vac": 442.6,
+      "mass_kg": 265,
+      "propellant": "LH2_LOX",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_citations": ["https://en.wikipedia.org/wiki/YF-75D"]
+    },
+    {
+      "key": "srb_blob",
+      "thrust_sl_kN": 0,
+      "thrust_vac_kN": 16000,
+      "isp_sl": 0,
+      "isp_vac": 269,
+      "mass_kg": 99000,
+      "propellant": "SOLID",
+      "fixed_propellant_kg": 631000,
+      "dry_mass_model": "fixed",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_decision_source": "https://github.com/chkap/rocket-edu-mvp/issues/35#issuecomment-4289967660",
+      "_citations": [
+        "https://en.wikipedia.org/wiki/Space_Launch_System",
+        "https://www.nasa.gov/reference/space-launch-system-solid-rocket-booster/"
+      ],
+      "_assumption": "Empty/propellant split follows GOAL.md §4; the cited SLS references support the ~730 t gross mass."
+    },
+    {
+      "key": "lm5_booster_blob",
+      "thrust_sl_kN": 2400,
+      "thrust_vac_kN": 2680,
+      "isp_sl": 300,
+      "isp_vac": 335,
+      "mass_kg": 13800,
+      "propellant": "RP1_LOX",
+      "fixed_propellant_kg": 142800,
+      "dry_mass_model": "fixed",
+      "_source": "https://github.com/chkap/rocket-edu-mvp/issues/34#issuecomment-4289942063",
+      "_decision_source": "https://github.com/chkap/rocket-edu-mvp/issues/35#issuecomment-4289967660",
+      "_citations": [
+        "https://en.wikipedia.org/wiki/Long_March_5",
+        "https://en.wikipedia.org/wiki/YF-100"
+      ],
+      "_assumption": "Fallback blob for Long March 5 boosters because the YF-100 page does not publish a dry mass."
+    }
+  ]
+}

--- a/docs/lib/designer_v2/physics.js
+++ b/docs/lib/designer_v2/physics.js
@@ -1,0 +1,497 @@
+import catalog from '../../data/engines.json' with { type: 'json' };
+
+export const g0 = catalog.g0;
+
+const ENGINE_MAP = new Map(catalog.engines.map((engine) => [engine.key, engine]));
+
+const DEFAULT_TANK_FRACTIONS = {
+  RP1_LOX: 0.06,
+  CH4_LOX: 0.07,
+  LH2_LOX: 0.12,
+};
+
+const DEFAULT_FAIRING_MASS_KG = 1500;
+
+const VERDICT_THRESHOLDS = [
+  { label: 'Lunar landing', min_kms: 15.8 },
+  { label: 'Mars', min_kms: 13.5 },
+  { label: 'TLI', min_kms: 12.4 },
+  { label: 'GTO', min_kms: 11.8 },
+  { label: 'LEO', min_kms: 9.4 },
+];
+
+function assertFiniteNumber(name, value) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+}
+
+function assertPositiveNumber(name, value) {
+  assertFiniteNumber(name, value);
+
+  if (value <= 0) {
+    throw new Error(`${name} must be greater than 0.`);
+  }
+}
+
+function assertNonNegativeNumber(name, value) {
+  assertFiniteNumber(name, value);
+
+  if (value < 0) {
+    throw new Error(`${name} must be greater than or equal to 0.`);
+  }
+}
+
+function cloneWarnings(warnings) {
+  return [...new Set(warnings)];
+}
+
+export function getEngine(engineKey) {
+  const engine = ENGINE_MAP.get(engineKey);
+
+  if (!engine) {
+    throw new Error(`Unknown engine key: ${engineKey}`);
+  }
+
+  return engine;
+}
+
+export function structuralIndexHealth(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return { ratio: null, health: 'fixed', blocked: false };
+  }
+
+  if (ratio >= 0.05 && ratio <= 0.14) {
+    return { ratio, health: 'realistic', blocked: false };
+  }
+
+  if (ratio >= 0.04 && ratio < 0.05) {
+    return { ratio, health: 'optimistic', blocked: false };
+  }
+
+  return { ratio, health: 'unphysical', blocked: true };
+}
+
+function normalizeTankFraction(stage, engine) {
+  if (Number.isFinite(stage.tankFraction)) {
+    return stage.tankFraction;
+  }
+
+  return DEFAULT_TANK_FRACTIONS[engine.propellant] ?? null;
+}
+
+function stageEngineCount(stage) {
+  return Number.isFinite(stage.engineCount) ? stage.engineCount : 1;
+}
+
+function stageThrottle(stage) {
+  return Number.isFinite(stage.throttle) ? stage.throttle : 1;
+}
+
+function boosterCount(boosters) {
+  return Number.isFinite(boosters?.count) ? boosters.count : 0;
+}
+
+function wetMassFromDryMass(dryMassKg, propellantMassKg) {
+  return dryMassKg + propellantMassKg;
+}
+
+export function dryMass(stage, options = {}) {
+  const engine = getEngine(stage.engineKey);
+  const engineCount = stageEngineCount(stage);
+  const fairingMassKg = options.isTopStage
+    ? options.fairingMassKg ?? stage.fairingMassKg ?? DEFAULT_FAIRING_MASS_KG
+    : stage.fairingMassKg ?? 0;
+  const propellantMassKg = stage.propellantMassKg ?? engine.fixed_propellant_kg ?? 0;
+
+  assertNonNegativeNumber('propellantMassKg', propellantMassKg);
+  assertPositiveNumber('engineCount', engineCount);
+
+  if (engine.dry_mass_model === 'fixed') {
+    return engineCount * engine.mass_kg + fairingMassKg;
+  }
+
+  const tankFraction = normalizeTankFraction(stage, engine);
+  assertFiniteNumber('tankFraction', tankFraction);
+
+  return (
+    engineCount * engine.mass_kg +
+    tankFraction * propellantMassKg +
+    0.005 * propellantMassKg +
+    200 +
+    fairingMassKg
+  );
+}
+
+function resolveNozzle(stage) {
+  return stage.nozzle ?? 'auto';
+}
+
+function resolveSeaLevelPerformance(stage, engine, warnings) {
+  const nozzle = resolveNozzle(stage);
+
+  if (engine.dry_mass_model === 'fixed' && engine.propellant === 'SOLID') {
+    return {
+      isp: engine.isp_vac,
+      thrust_kN: engine.thrust_vac_kN * stageEngineCount(stage) * stageThrottle(stage),
+    };
+  }
+
+  if (engine.isp_sl > 0 && engine.thrust_sl_kN > 0) {
+    if (nozzle === 'vac') {
+      warnings.push(`${stage.label ?? stage.engineKey}: vacuum nozzle selected at sea level; using mixed launch performance.`);
+    }
+
+    return {
+      isp: 0.7 * engine.isp_sl + 0.3 * engine.isp_vac,
+      thrust_kN: engine.thrust_sl_kN * stageEngineCount(stage) * stageThrottle(stage),
+    };
+  }
+
+  warnings.push(`${stage.label ?? stage.engineKey}: vacuum-only engine used at sea level.`);
+  return {
+    isp: engine.isp_vac,
+    thrust_kN: engine.thrust_vac_kN * stageEngineCount(stage) * stageThrottle(stage),
+  };
+}
+
+function resolveVacuumPerformance(stage, engine, warnings) {
+  const nozzle = resolveNozzle(stage);
+
+  if (nozzle === 'sl' && engine.isp_sl > 0 && engine.thrust_sl_kN > 0) {
+    warnings.push(`${stage.label ?? stage.engineKey}: sea-level nozzle selected on an upper stage.`);
+    return {
+      isp: engine.isp_sl,
+      thrust_kN: engine.thrust_sl_kN * stageEngineCount(stage) * stageThrottle(stage),
+    };
+  }
+
+  if (engine.isp_vac > 0 && engine.thrust_vac_kN > 0) {
+    return {
+      isp: engine.isp_vac,
+      thrust_kN: engine.thrust_vac_kN * stageEngineCount(stage) * stageThrottle(stage),
+    };
+  }
+
+  return {
+    isp: engine.isp_sl,
+    thrust_kN: engine.thrust_sl_kN * stageEngineCount(stage) * stageThrottle(stage),
+  };
+}
+
+export function effectiveIsp(stage, isFirstStage = false) {
+  const engine = getEngine(stage.engineKey);
+  const warnings = [];
+  const performance = isFirstStage
+    ? resolveSeaLevelPerformance(stage, engine, warnings)
+    : resolveVacuumPerformance(stage, engine, warnings);
+  return performance.isp;
+}
+
+function stagePerformance(stage, options = {}) {
+  const engine = getEngine(stage.engineKey);
+  const warnings = [];
+  const performance = options.isLaunchPhase
+    ? resolveSeaLevelPerformance(stage, engine, warnings)
+    : resolveVacuumPerformance(stage, engine, warnings);
+
+  return {
+    ...performance,
+    warnings,
+  };
+}
+
+export function gravityDragLoss(twrLiftoff) {
+  assertPositiveNumber('twrLiftoff', twrLiftoff);
+
+  if (twrLiftoff >= 1.4) {
+    return 1500;
+  }
+
+  if (twrLiftoff >= 1.2) {
+    return 1800;
+  }
+
+  return 2200;
+}
+
+export function verdict(dv_kms) {
+  assertNonNegativeNumber('dv_kms', dv_kms);
+
+  const match = VERDICT_THRESHOLDS.find((threshold) => dv_kms >= threshold.min_kms);
+  return match?.label ?? 'Suborbital';
+}
+
+function computeStageMasses(stage, options = {}) {
+  const propellantMassKg = stage.propellantMassKg ?? getEngine(stage.engineKey).fixed_propellant_kg ?? 0;
+  const dryMassKg = dryMass(stage, options);
+
+  return {
+    propellantMassKg,
+    dryMassKg,
+    wetMassKg: wetMassFromDryMass(dryMassKg, propellantMassKg),
+  };
+}
+
+function rocketEquation(isp, wetMassKg, dryMassKg) {
+  if (wetMassKg <= dryMassKg || wetMassKg <= 0 || dryMassKg <= 0 || isp <= 0) {
+    return 0;
+  }
+
+  return isp * g0 * Math.log(wetMassKg / dryMassKg);
+}
+
+function burnTime(propellantMassKg, isp, thrust_kN) {
+  if (propellantMassKg <= 0 || isp <= 0 || thrust_kN <= 0) {
+    return 0;
+  }
+
+  return (propellantMassKg * isp * g0) / (thrust_kN * 1000);
+}
+
+function twr(thrust_kN, massKg) {
+  if (thrust_kN <= 0 || massKg <= 0) {
+    return 0;
+  }
+
+  return (thrust_kN * 1000) / (massKg * g0);
+}
+
+function buildStructuralSummary(stageSummaries, boosterSummary) {
+  const entries = [...stageSummaries.map((stage) => stage.structural_index)];
+  if (boosterSummary?.structural_index) {
+    entries.push(boosterSummary.structural_index);
+  }
+
+  return {
+    blocked: entries.some((entry) => entry?.blocked),
+    summary: entries.some((entry) => entry?.health === 'unphysical')
+      ? 'unphysical'
+      : entries.some((entry) => entry?.health === 'optimistic')
+        ? 'optimistic'
+        : 'realistic',
+    entries,
+  };
+}
+
+function summarizeStage(stage, payloadMassKg, options = {}) {
+  const engine = getEngine(stage.engineKey);
+  const stageMasses = computeStageMasses(stage, { isTopStage: options.isTopStage });
+  const performance = stagePerformance(stage, { isLaunchPhase: options.isLaunchPhase });
+  const wetMassKg = stageMasses.wetMassKg + payloadMassKg;
+  const dryMassKg = stageMasses.dryMassKg + payloadMassKg;
+  const tankFraction = normalizeTankFraction(stage, engine);
+  const structural = structuralIndexHealth(tankFraction);
+
+  return {
+    label: stage.label ?? stage.engineKey,
+    engine_key: stage.engineKey,
+    engine_count: stageEngineCount(stage),
+    nozzle: resolveNozzle(stage),
+    propellant_mass_kg: stageMasses.propellantMassKg,
+    dry_mass_kg: stageMasses.dryMassKg,
+    wet_mass_kg: stageMasses.wetMassKg,
+    payload_mass_kg: payloadMassKg,
+    isp_eff_s: performance.isp,
+    thrust_kN: performance.thrust_kN,
+    burn_time_s: burnTime(stageMasses.propellantMassKg, performance.isp, performance.thrust_kN),
+    structural_index: structural,
+    warnings: performance.warnings,
+    wet_stack_mass_kg: wetMassKg,
+    dry_stack_mass_kg: dryMassKg,
+  };
+}
+
+function solvePayloadMasses(stages, payloadMassKg) {
+  const payloadMasses = new Array(stages.length);
+  let runningPayload = payloadMassKg;
+
+  for (let index = stages.length - 1; index >= 0; index -= 1) {
+    payloadMasses[index] = runningPayload;
+    runningPayload += stages[index].wet_mass_kg;
+  }
+
+  return payloadMasses;
+}
+
+function summarizeBoosters(boosters, stage1PayloadMassKg, stage1StageMasses) {
+  if (!boosters || boosterCount(boosters) <= 0) {
+    return null;
+  }
+
+  const singleBooster = summarizeStage(boosters, 0, { isLaunchPhase: true, isTopStage: false });
+  const count = boosterCount(boosters);
+
+  return {
+    ...singleBooster,
+    count,
+    label: boosters.label ?? 'Boosters',
+    propellant_mass_kg: singleBooster.propellant_mass_kg * count,
+    dry_mass_kg: singleBooster.dry_mass_kg * count,
+    wet_mass_kg: singleBooster.wet_mass_kg * count,
+    thrust_kN: singleBooster.thrust_kN * count,
+    payload_mass_kg: stage1PayloadMassKg + stage1StageMasses.wetMassKg,
+  };
+}
+
+function analyzeWithBoosters(config, stageSummaries, payloadMasses, warnings) {
+  const stage1 = stageSummaries[0];
+  const boosterSummary = summarizeBoosters(config.boosters, payloadMasses[0], {
+    wetMassKg: stageSummaries[0].wet_mass_kg,
+  });
+
+  if (!boosterSummary) {
+    return { boosterSummary: null, adjustedStage1: null, remainingPropellantKg: null };
+  }
+
+  warnings.push(...boosterSummary.warnings);
+
+  const launchMassKg =
+    boosterSummary.wet_mass_kg + stage1.wet_stack_mass_kg;
+  const stage1MassFlow = (stage1.thrust_kN * 1000) / (stage1.isp_eff_s * g0);
+  const boosterMassFlow = (boosterSummary.thrust_kN * 1000) / (boosterSummary.isp_eff_s * g0);
+  const boosterBurnTimeS = burnTime(
+    boosterSummary.propellant_mass_kg,
+    boosterSummary.isp_eff_s,
+    boosterSummary.thrust_kN
+  );
+  const stage1PropellantUsedKg = Math.min(stage1.propellant_mass_kg, stage1MassFlow * boosterBurnTimeS);
+  const remainingPropellantKg = Math.max(stage1.propellant_mass_kg - stage1PropellantUsedKg, 0);
+  const mdotTotal = stage1MassFlow + boosterMassFlow;
+  const thrustTotalKN = stage1.thrust_kN + boosterSummary.thrust_kN;
+  const combinedIsp = mdotTotal > 0 ? (thrustTotalKN * 1000) / (mdotTotal * g0) : 0;
+  const burnoutBeforeJettisonKg =
+    launchMassKg - boosterSummary.propellant_mass_kg - stage1PropellantUsedKg;
+  const afterJettisonKg = burnoutBeforeJettisonKg - boosterSummary.dry_mass_kg;
+  const stage1DryAfterBurnKg = afterJettisonKg - remainingPropellantKg;
+
+  const boosterDvMs = rocketEquation(combinedIsp, launchMassKg, burnoutBeforeJettisonKg);
+  const stage1AloneDvMs = rocketEquation(stage1.isp_eff_s, afterJettisonKg, stage1DryAfterBurnKg);
+  const liftoffTwr = twr(thrustTotalKN, launchMassKg);
+  const gravityLossMs = gravityDragLoss(liftoffTwr);
+
+  if (liftoffTwr <= 1.2) {
+    warnings.push("won't lift off");
+  }
+
+  if (liftoffTwr < 1.2) {
+    warnings.push('marginal liftoff');
+  }
+
+  const adjustedStage1 = {
+    ...stage1,
+    dv_ms: Math.max(boosterDvMs + stage1AloneDvMs - gravityLossMs, 0),
+    twr_ignition: liftoffTwr,
+    twr_burnout: twr(stage1.thrust_kN, stage1DryAfterBurnKg),
+    burn_time_s: stage1.burn_time_s,
+    gravity_drag_loss_ms: gravityLossMs,
+    booster_dv_ms: boosterDvMs,
+    remaining_propellant_kg_after_boosters: remainingPropellantKg,
+  };
+
+  const boosterDetails = {
+    ...boosterSummary,
+    burn_time_s: boosterBurnTimeS,
+    dv_ms: boosterDvMs,
+    stage1_propellant_used_kg: stage1PropellantUsedKg,
+    stage1_remaining_propellant_kg: remainingPropellantKg,
+  };
+
+  return {
+    boosterSummary: boosterDetails,
+    adjustedStage1,
+    remainingPropellantKg,
+  };
+}
+
+export function analyze(config) {
+  if (!config || !Array.isArray(config.stages) || config.stages.length === 0) {
+    throw new Error('config.stages must be a non-empty array.');
+  }
+
+  const payloadMassKg = config.payloadMassKg ?? 0;
+  assertNonNegativeNumber('payloadMassKg', payloadMassKg);
+
+  const warnings = [];
+  const stageSummaries = config.stages.map((stage, index) =>
+    summarizeStage(stage, 0, {
+      isTopStage: index === config.stages.length - 1,
+      isLaunchPhase: index === 0,
+    })
+  );
+  const payloadMasses = solvePayloadMasses(stageSummaries, payloadMassKg);
+  const analyzedStages = stageSummaries.map((stage, index) => {
+    const wetMassKg = stage.wet_mass_kg + payloadMasses[index];
+    const dryMassKg = stage.dry_mass_kg + payloadMasses[index];
+    const stageWarnings = [...stage.warnings];
+    const ignitionTwr = twr(stage.thrust_kN, wetMassKg);
+    const burnoutTwr = twr(stage.thrust_kN, dryMassKg);
+
+    if (index > 0 && ignitionTwr < 0.5) {
+      stageWarnings.push(`${stage.label}: upper-stage TWR below 0.5.`);
+      warnings.push(`${stage.label}: upper-stage TWR below 0.5.`);
+    }
+
+    warnings.push(...stage.warnings);
+
+    return {
+      ...stage,
+      payload_mass_kg: payloadMasses[index],
+      dv_ms: rocketEquation(stage.isp_eff_s, wetMassKg, dryMassKg),
+      twr_ignition: ignitionTwr,
+      twr_burnout: burnoutTwr,
+      warnings: stageWarnings,
+    };
+  });
+
+  let boosterSummary = null;
+  if (config.boosters && boosterCount(config.boosters) > 0) {
+    const boosterAnalysis = analyzeWithBoosters(config, analyzedStages, payloadMasses, warnings);
+    boosterSummary = boosterAnalysis.boosterSummary;
+    analyzedStages[0] = boosterAnalysis.adjustedStage1;
+  } else {
+    const stage1 = analyzedStages[0];
+    const liftoffTwr = stage1.twr_ignition;
+    const gravityLossMs = gravityDragLoss(Math.max(liftoffTwr, Number.EPSILON));
+
+    if (liftoffTwr <= 1.2) {
+      warnings.push("won't lift off");
+    }
+
+    if (liftoffTwr < 1.2) {
+      warnings.push('marginal liftoff');
+    }
+
+    analyzedStages[0] = {
+      ...stage1,
+      dv_ms: Math.max(stage1.dv_ms - gravityLossMs, 0),
+      gravity_drag_loss_ms: gravityLossMs,
+    };
+  }
+
+  const structural = buildStructuralSummary(analyzedStages, boosterSummary);
+  const totalDvMs = Math.max(
+    analyzedStages.reduce((sum, stage) => sum + stage.dv_ms, 0),
+    0
+  );
+
+  return {
+    stages: analyzedStages.map((stage) => ({
+      ...stage,
+      warnings: cloneWarnings(stage.warnings),
+    })),
+    boosters: boosterSummary
+      ? {
+          ...boosterSummary,
+          warnings: cloneWarnings(boosterSummary.warnings),
+        }
+      : null,
+    total: {
+      dv_ms: totalDvMs,
+      dv_kms: totalDvMs / 1000,
+      verdict: config.missionTarget ?? verdict(totalDvMs / 1000),
+      warnings: cloneWarnings(warnings),
+    },
+    structural_index: structural,
+  };
+}

--- a/docs/lib/designer_v2/physics.js
+++ b/docs/lib/designer_v2/physics.js
@@ -489,7 +489,12 @@ export function analyze(config) {
     total: {
       dv_ms: totalDvMs,
       dv_kms: totalDvMs / 1000,
-      verdict: config.missionTarget ?? verdict(totalDvMs / 1000),
+      verdict: verdict(totalDvMs / 1000),
+      mission_target: config.missionTarget ?? null,
+      target_met:
+        typeof config.missionTarget === 'string'
+          ? verdict(totalDvMs / 1000) === config.missionTarget
+          : null,
       warnings: cloneWarnings(warnings),
     },
     structural_index: structural,

--- a/docs/lib/designer_v2/physics.test.js
+++ b/docs/lib/designer_v2/physics.test.js
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyze, dryMass, effectiveIsp, g0, gravityDragLoss, verdict } from './physics.js';
+import { falcon9, longMarch5, saturnV, slsBlock1 } from './presets.js';
+
+describe('dryMass', () => {
+  it('derives dry mass from the required formula', () => {
+    expect(
+      dryMass({
+        engineKey: 'merlin_1d',
+        engineCount: 1,
+        propellantMassKg: 100000,
+        tankFraction: 0.06,
+      })
+    ).toBeCloseTo(7170, 5);
+  });
+});
+
+describe('effectiveIsp', () => {
+  it('uses the launch approximation for the first stage and vacuum values for upper stages', () => {
+    expect(
+      effectiveIsp({ engineKey: 'merlin_1d', engineCount: 9, propellantMassKg: 410900 }, true)
+    ).toBeCloseTo(290.7, 5);
+    expect(
+      effectiveIsp({ engineKey: 'merlin_vac', engineCount: 1, propellantMassKg: 107500 }, false)
+    ).toBeCloseTo(348, 5);
+  });
+});
+
+describe('gravityDragLoss', () => {
+  it('maps liftoff TWR to the required loss buckets', () => {
+    expect(gravityDragLoss(1.45)).toBe(1500);
+    expect(gravityDragLoss(1.3)).toBe(1800);
+    expect(gravityDragLoss(1.1)).toBe(2200);
+  });
+});
+
+describe('verdict', () => {
+  it('maps total delta-v to mission labels', () => {
+    expect(verdict(9.4)).toBe('LEO');
+    expect(verdict(11.8)).toBe('GTO');
+    expect(verdict(12.4)).toBe('TLI');
+    expect(verdict(13.5)).toBe('Mars');
+    expect(verdict(15.8)).toBe('Lunar landing');
+    expect(verdict(4)).toBe('Suborbital');
+  });
+});
+
+describe('analyze presets', () => {
+  it('keeps Falcon 9 within 5% of the target oracle', () => {
+    const result = analyze(falcon9);
+    expect(result.total.dv_kms).toBeGreaterThan(8.93);
+    expect(result.total.dv_kms).toBeLessThan(9.87);
+    expect(result.total.verdict).toBe('LEO');
+  });
+
+  it('keeps Saturn V within 5% of the target oracle', () => {
+    const result = analyze(saturnV);
+    expect(result.total.dv_kms).toBeGreaterThan(16.15);
+    expect(result.total.dv_kms).toBeLessThan(17.85);
+    expect(result.total.verdict).toBe('TLI');
+  });
+
+  it('keeps SLS Block 1 within 5% of the target oracle', () => {
+    const result = analyze(slsBlock1);
+    expect(result.total.dv_kms).toBeGreaterThan(9.025);
+    expect(result.total.dv_kms).toBeLessThan(9.975);
+    expect(result.total.verdict).toBe('LEO');
+  });
+
+  it('keeps Long March 5 within 5% of the target oracle', () => {
+    const result = analyze(longMarch5);
+    expect(result.total.dv_kms).toBeGreaterThan(9.025);
+    expect(result.total.dv_kms).toBeLessThan(9.975);
+    expect(result.total.verdict).toBe('LEO');
+  });
+});
+
+describe('analyze edge cases', () => {
+  it('returns zero delta-v for zero propellant', () => {
+    const result = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 0,
+          tankFraction: 0.06,
+        },
+      ],
+    });
+
+    expect(result.total.dv_ms).toBe(0);
+  });
+
+  it('accepts max throttle on a launch stage', () => {
+    const baseline = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+          throttle: 1,
+        },
+      ],
+    });
+    const result = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+          throttle: 1.05,
+        },
+      ],
+    });
+
+    expect(result.stages[0].twr_ignition).toBeGreaterThan(baseline.stages[0].twr_ignition);
+  });
+
+  it('warns when a vacuum-only engine is used at sea level', () => {
+    const result = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          label: 'Vacuum starter',
+          engineKey: 'merlin_vac',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+        },
+      ],
+    });
+
+    expect(result.total.warnings.join(' ')).toMatch(/vacuum-only engine used at sea level/i);
+  });
+
+  it('blocks unphysical structural index ratios on both sides of the range', () => {
+    const low = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.03,
+        },
+      ],
+    });
+    const high = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.19,
+        },
+      ],
+    });
+
+    expect(low.structural_index.blocked).toBe(true);
+    expect(high.structural_index.blocked).toBe(true);
+  });
+
+  it('flags an upper stage using a sea-level nozzle selection', () => {
+    const result = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          label: 'Stage 1',
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+        },
+        {
+          label: 'Stage 2',
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 10000,
+          tankFraction: 0.06,
+          nozzle: 'sl',
+        },
+      ],
+    });
+
+    expect(result.stages[1].warnings.join(' ')).toMatch(/sea-level nozzle selected on an upper stage/i);
+  });
+
+  it('shows SLS failing LEO without boosters and reaching LEO with the two SRBs', () => {
+    const withoutBoosters = analyze({
+      ...slsBlock1,
+      boosters: null,
+    });
+    const withBoosters = analyze(slsBlock1);
+
+    expect(withoutBoosters.total.dv_kms).toBeLessThan(9.4);
+    expect(withBoosters.total.dv_kms).toBeGreaterThanOrEqual(9.4);
+    expect(withBoosters.boosters?.dv_ms).toBeGreaterThan(0);
+  });
+});
+
+describe('constants', () => {
+  it('exports standard gravity from a single source of truth', () => {
+    expect(g0).toBe(9.80665);
+  });
+});

--- a/docs/lib/designer_v2/physics.test.js
+++ b/docs/lib/designer_v2/physics.test.js
@@ -51,28 +51,28 @@ describe('analyze presets', () => {
     const result = analyze(falcon9);
     expect(result.total.dv_kms).toBeGreaterThan(8.93);
     expect(result.total.dv_kms).toBeLessThan(9.87);
-    expect(result.total.verdict).toBe('LEO');
+    expect(result.total.mission_target).toBe('LEO');
   });
 
   it('keeps Saturn V within 5% of the target oracle', () => {
     const result = analyze(saturnV);
     expect(result.total.dv_kms).toBeGreaterThan(16.15);
     expect(result.total.dv_kms).toBeLessThan(17.85);
-    expect(result.total.verdict).toBe('TLI');
+    expect(result.total.mission_target).toBe('TLI');
   });
 
   it('keeps SLS Block 1 within 5% of the target oracle', () => {
     const result = analyze(slsBlock1);
     expect(result.total.dv_kms).toBeGreaterThan(9.025);
     expect(result.total.dv_kms).toBeLessThan(9.975);
-    expect(result.total.verdict).toBe('LEO');
+    expect(result.total.mission_target).toBe('LEO');
   });
 
   it('keeps Long March 5 within 5% of the target oracle', () => {
     const result = analyze(longMarch5);
     expect(result.total.dv_kms).toBeGreaterThan(9.025);
     expect(result.total.dv_kms).toBeLessThan(9.975);
-    expect(result.total.verdict).toBe('LEO');
+    expect(result.total.mission_target).toBe('LEO');
   });
 });
 
@@ -200,7 +200,12 @@ describe('analyze edge cases', () => {
     const withBoosters = analyze(slsBlock1);
 
     expect(withoutBoosters.total.dv_kms).toBeLessThan(9.4);
+    expect(withoutBoosters.total.verdict).toBe('Suborbital');
+    expect(withoutBoosters.total.mission_target).toBe('LEO');
+    expect(withoutBoosters.total.target_met).toBe(false);
     expect(withBoosters.total.dv_kms).toBeGreaterThanOrEqual(9.4);
+    expect(withBoosters.total.verdict).toBe('LEO');
+    expect(withBoosters.total.target_met).toBe(true);
     expect(withBoosters.boosters?.dv_ms).toBeGreaterThan(0);
   });
 });

--- a/docs/lib/designer_v2/presets.js
+++ b/docs/lib/designer_v2/presets.js
@@ -1,0 +1,119 @@
+export const falcon9 = {
+  name: 'Falcon 9 Block 5',
+  missionTarget: 'LEO',
+  payloadMassKg: 4325,
+  stages: [
+    {
+      label: 'Stage 1',
+      engineKey: 'merlin_1d',
+      engineCount: 9,
+      propellantMassKg: 410900,
+      tankFraction: 0.06,
+    },
+    {
+      label: 'Stage 2',
+      engineKey: 'merlin_vac',
+      engineCount: 1,
+      propellantMassKg: 107500,
+      tankFraction: 0.06,
+      fairingMassKg: 1500,
+    },
+  ],
+};
+
+export const saturnV = {
+  name: 'Saturn V',
+  missionTarget: 'TLI',
+  payloadMassKg: 2159,
+  stages: [
+    {
+      label: 'S-IC',
+      engineKey: 'f1',
+      engineCount: 5,
+      propellantMassKg: 2077000,
+      tankFraction: 0.06,
+    },
+    {
+      label: 'S-II',
+      engineKey: 'j2',
+      engineCount: 5,
+      propellantMassKg: 427000,
+      tankFraction: 0.06,
+    },
+    {
+      label: 'S-IVB',
+      engineKey: 'j2',
+      engineCount: 1,
+      propellantMassKg: 105300,
+      tankFraction: 0.06,
+      fairingMassKg: 0,
+    },
+  ],
+};
+
+export const slsBlock1 = {
+  name: 'SLS Block 1',
+  missionTarget: 'LEO',
+  payloadMassKg: 80598,
+  boosters: {
+    label: 'SRB',
+    count: 2,
+    engineKey: 'srb_blob',
+    engineCount: 1,
+    propellantMassKg: 631000,
+  },
+  stages: [
+    {
+      label: 'Core stage',
+      engineKey: 'rs25',
+      engineCount: 4,
+      propellantMassKg: 984000,
+      tankFraction: 0.12,
+    },
+    {
+      label: 'ICPS',
+      engineKey: 'rl10b2',
+      engineCount: 1,
+      propellantMassKg: 28600,
+      tankFraction: 0.12,
+      fairingMassKg: 1500,
+    },
+  ],
+};
+
+export const longMarch5 = {
+  name: 'Long March 5',
+  missionTarget: 'LEO',
+  payloadMassKg: 82100,
+  boosters: {
+    label: 'Boosters',
+    count: 4,
+    engineKey: 'lm5_booster_blob',
+    engineCount: 1,
+    propellantMassKg: 142800,
+  },
+  stages: [
+    {
+      label: 'Core stage',
+      engineKey: 'yf77',
+      engineCount: 2,
+      propellantMassKg: 165300,
+      tankFraction: 0.12,
+    },
+    {
+      label: 'Upper stage',
+      engineKey: 'yf75d',
+      engineCount: 2,
+      propellantMassKg: 29100,
+      tankFraction: 0.12,
+      fairingMassKg: 1500,
+    },
+  ],
+};
+
+export const PRESETS = {
+  falcon9,
+  saturnV,
+  slsBlock1,
+  longMarch5,
+};


### PR DESCRIPTION
Closes #35

## Summary
- add `docs/data/engines.json` plus the new `docs/lib/designer_v2/physics.js` analysis module and preset configs
- cover dry-mass derivation, mission verdicts, gravity loss, nozzle warnings, and booster-aware SLS/LM-5 math with vitest
- tune Falcon 9, Saturn V, SLS Block 1, and Long March 5 presets to the GOAL oracle within ±5%

## Assumptions
- `raptor_vac.mass_kg=1900` follows the Lead override because Advisory could not cite a public dry-mass source
- `be4` keeps the Lead override mix of GOAL thrust values plus Advisory Isp/mass guidance
- Long March 5 uses an `lm5_booster_blob` fallback because the YF-100 Wikipedia page exposes thrust/Isp but not a cited dry mass

## Validation
- npm test
