### PR TITLE
Fix fixed-mass structural badge

### DIFF
--- a/docs/designer-v2.js
+++ b/docs/designer-v2.js
@@ -649,12 +649,19 @@ function structuralBadge(entry) {
     return '—';
   }
 
-  const icon = entry.health === 'realistic' ? '🟢' : entry.health === 'optimistic' ? '🟡' : '🔴';
+  const icon =
+    entry.health === 'realistic'
+      ? '🟢'
+      : entry.health === 'optimistic'
+        ? '🟡'
+        : entry.health === 'fixed'
+          ? '⚪'
+          : '🔴';
   const label = t(`designer_v2.structural.${entry.health}`);
+  const ratio =
+    typeof entry.ratio === 'number' ? ` (${ratioFmt.format(entry.ratio)})` : '';
 
-  return `<span class="designer-v2-structural is-${entry.health}">${icon} ${label} (${ratioFmt.format(
-    entry.ratio ?? 0
-  )})</span>`;
+  return `<span class="designer-v2-structural is-${entry.health}">${icon} ${label}${ratio}</span>`;
 }
 
 function liquidBoosterEngines() {

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -212,6 +212,7 @@
   "designer_v2.metric.structural": "Structural index",
   "designer_v2.structural.realistic": "Realistic",
   "designer_v2.structural.optimistic": "Optimistic",
+  "designer_v2.structural.fixed": "Fixed mass model",
   "designer_v2.structural.unphysical": "Blocked",
   "designer_v2.summary.title": "Sticky mission summary",
   "designer_v2.summary.total_dv": "Total Δv",

--- a/docs/i18n/zh.json
+++ b/docs/i18n/zh.json
@@ -212,6 +212,7 @@
   "designer_v2.metric.structural": "结构指数",
   "designer_v2.structural.realistic": "合理",
   "designer_v2.structural.optimistic": "偏乐观",
+  "designer_v2.structural.fixed": "固定质量模型",
   "designer_v2.structural.unphysical": "阻止分析",
   "designer_v2.summary.title": "粘性任务摘要",
   "designer_v2.summary.total_dv": "总 Δv",

--- a/docs/lib/i18n.test.js
+++ b/docs/lib/i18n.test.js
@@ -201,6 +201,7 @@ describe('t and formatMessage', () => {
     });
 
     expect(t('nav.compare')).toBe('火箭对比');
+    expect(t('designer_v2.structural.fixed')).toBe('固定质量模型');
     expect(formatMessage('designer.stage.count.other', { count: 3 })).toBe('3 级');
   });
 


### PR DESCRIPTION
Closes #44

## What changed
- add the missing `designer_v2.structural.fixed` translation keys in English and Chinese
- render fixed-mass-model structural badges with a neutral icon instead of the blocked red state
- omit the structural ratio suffix when the ratio is undefined and add a regression test for the new i18n key