### PR TITLE
Refresh shell styling, theme toggle, and mobile layout

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -77,10 +77,16 @@
             <li><a href="./compare.html" aria-current="page" data-i18n="nav.compare"></a></li>
             <li><a href="./designer-v2.html" data-i18n="nav.designer_v2"></a></li>
           </ul>
-          <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-            <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-            <span class="lang-switcher-separator">|</span>
-            <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+          <div class="nav-controls">
+            <div class="theme-switcher">
+              <span class="theme-switcher-label" data-i18n="theme.label"></span>
+              <button type="button" class="theme-toggle" data-theme-toggle></button>
+            </div>
+            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
+              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
+              <span class="lang-switcher-separator">|</span>
+              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+            </div>
           </div>
         </div>
       </nav>

--- a/docs/designer-v2.css
+++ b/docs/designer-v2.css
@@ -174,9 +174,9 @@
 }
 
 .designer-v2-toggle input[type='radio']:checked + span {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-text);
 }
 
 .designer-v2-note {
@@ -292,8 +292,8 @@
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
   border-radius: 999px;
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: var(--accent-soft);
+  color: var(--accent-text);
   font-weight: 700;
 }
 
@@ -304,8 +304,8 @@
 
 .designer-v2-verdict-pill.is-mars,
 .designer-v2-verdict-pill.is-lunar {
-  background: #ede9fe;
-  color: #6d28d9;
+  background: color-mix(in srgb, var(--accent-soft) 70%, rebeccapurple 30%);
+  color: var(--accent-text);
 }
 
 .designer-v2-summary-subtitle {
@@ -317,7 +317,7 @@
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 2.9rem 0.75rem 1rem;
-  background: linear-gradient(90deg, #dbeafe, #ede9fe);
+  background: linear-gradient(90deg, var(--accent-gradient-start), var(--accent-gradient-end));
   min-height: 5.75rem;
 }
 
@@ -333,7 +333,7 @@
   position: absolute;
   inset: 0 auto 0 0;
   width: min(var(--mission-progress, 0%), 100%);
-  background: linear-gradient(90deg, #1d4ed8, #7c3aed);
+  background: linear-gradient(90deg, var(--primary), color-mix(in srgb, var(--primary) 65%, rebeccapurple 35%));
 }
 
 .designer-v2-mission-current {
@@ -343,7 +343,7 @@
   width: 1rem;
   height: 1rem;
   border-radius: 999px;
-  border: 2px solid #ffffff;
+  border: 2px solid var(--surface-strong);
   background: #0f172a;
   transform: translateX(-50%);
 }
@@ -379,19 +379,19 @@
   height: 1.25rem;
   margin-bottom: 0.4rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--surface-strong);
   color: var(--text);
 }
 
 .designer-v2-mission-markers li.is-hit strong,
 .designer-v2-mission-markers li.is-target strong {
-  background: #1d4ed8;
+  background: var(--primary);
   color: #ffffff;
 }
 
 .designer-v2-mission-markers li.is-target span {
   font-weight: 700;
-  color: #1d4ed8;
+  color: var(--accent-text);
 }
 
 .designer-v2-warning-list {
@@ -425,4 +425,69 @@
   color: var(--danger);
   background: var(--danger-bg);
   border: 1px solid var(--danger-border);
+}
+
+@media (max-width: 720px) {
+  .designer-v2-toolbar-actions,
+  .designer-v2-preset-field {
+    width: 100%;
+  }
+
+  .designer-v2-button-row > button {
+    flex: 1 1 12rem;
+  }
+
+  .designer-v2-summary-header {
+    align-items: stretch;
+  }
+
+  .designer-v2-summary-header > button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 540px) {
+  .designer-v2-card,
+  .designer-v2-summary-panel {
+    padding: 0.85rem;
+  }
+
+  .designer-v2-field-grid,
+  .designer-v2-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .designer-v2-range-row {
+    grid-template-columns: 1fr;
+  }
+
+  .designer-v2-toggle,
+  .designer-v2-toggle label,
+  .designer-v2-toggle.is-wide label {
+    width: 100%;
+  }
+
+  .designer-v2-button-row > button,
+  .designer-v2-card-tools > button,
+  .designer-v2-drag-handle {
+    width: 100%;
+  }
+
+  .designer-v2-card-header,
+  .designer-v2-card-tools {
+    align-items: stretch;
+  }
+
+  .designer-v2-mission-bar {
+    padding-left: 0.6rem;
+    padding-right: 0.6rem;
+  }
+
+  .designer-v2-mission-markers li {
+    width: 3.75rem;
+  }
+
+  .designer-v2-mission-markers span {
+    font-size: 0.72rem;
+  }
 }

--- a/docs/designer-v2.html
+++ b/docs/designer-v2.html
@@ -25,10 +25,16 @@
             <li><a href="./compare.html" data-i18n="nav.compare"></a></li>
             <li><a href="./designer-v2.html" aria-current="page" data-i18n="nav.designer_v2"></a></li>
           </ul>
-          <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-            <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-            <span class="lang-switcher-separator">|</span>
-            <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+          <div class="nav-controls">
+            <div class="theme-switcher">
+              <span class="theme-switcher-label" data-i18n="theme.label"></span>
+              <button type="button" class="theme-toggle" data-theme-toggle></button>
+            </div>
+            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
+              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
+              <span class="lang-switcher-separator">|</span>
+              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+            </div>
           </div>
         </div>
       </nav>

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -74,18 +74,25 @@ describe('designer-v2 smoke flow', () => {
 
     const presetSelect = document.getElementById('preset-select');
     const analyzeButton = document.getElementById('analyze-button');
+    const themeToggle = document.querySelector('[data-theme-toggle]');
 
     expect(presetSelect).not.toBeNull();
     expect(analyzeButton).not.toBeNull();
+    expect(themeToggle).not.toBeNull();
 
     presetSelect.value = 'falcon9';
     presetSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    themeToggle.click();
     analyzeButton.click();
 
     await waitFor(() => {
       expect(document.getElementById('verdict-pill')?.textContent).toContain('LEO');
       expect(document.getElementById('summary-status')?.textContent).toContain('Ready');
     });
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(window.localStorage.getItem('rocket-theme')).toBe('dark');
+    expect(presetSelect.value).toBe('falcon9');
 
     const totalDvText = document.getElementById('total-dv')?.textContent ?? '';
     const totalDv = Number(totalDvText.replace(/[^\d.]/g, ''));

--- a/docs/designer.html
+++ b/docs/designer.html
@@ -25,10 +25,16 @@
             <li><a href="./compare.html" data-i18n="nav.compare"></a></li>
             <li><a href="./designer-v2.html" data-i18n="nav.designer_v2"></a></li>
           </ul>
-          <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-            <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-            <span class="lang-switcher-separator">|</span>
-            <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+          <div class="nav-controls">
+            <div class="theme-switcher">
+              <span class="theme-switcher-label" data-i18n="theme.label"></span>
+              <button type="button" class="theme-toggle" data-theme-toggle></button>
+            </div>
+            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
+              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
+              <span class="lang-switcher-separator">|</span>
+              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+            </div>
           </div>
         </div>
       </nav>

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -1,6 +1,11 @@
 {
   "lang.english": "EN",
   "lang.chinese": "中文",
+  "theme.label": "Theme",
+  "theme.light": "Light",
+  "theme.dark": "Dark",
+  "theme.switch_to_light": "Switch to light theme",
+  "theme.switch_to_dark": "Switch to dark theme",
   "nav.primary": "Primary navigation",
   "nav.language_switcher": "Language switcher",
   "nav.index": "Equation guide",

--- a/docs/i18n/zh.json
+++ b/docs/i18n/zh.json
@@ -1,6 +1,11 @@
 {
   "lang.english": "EN",
   "lang.chinese": "中文",
+  "theme.label": "主题",
+  "theme.light": "浅色",
+  "theme.dark": "深色",
+  "theme.switch_to_light": "切换到浅色主题",
+  "theme.switch_to_dark": "切换到深色主题",
   "nav.primary": "主导航",
   "nav.language_switcher": "语言切换",
   "nav.index": "公式指南",

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,10 +31,16 @@
             <li><a href="#worked-example" data-i18n="nav.worked_example"></a></li>
             <li><a href="#intuition" data-i18n="nav.intuition"></a></li>
           </ul>
-          <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-            <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-            <span class="lang-switcher-separator">|</span>
-            <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+          <div class="nav-controls">
+            <div class="theme-switcher">
+              <span class="theme-switcher-label" data-i18n="theme.label"></span>
+              <button type="button" class="theme-toggle" data-theme-toggle></button>
+            </div>
+            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
+              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
+              <span class="lang-switcher-separator">|</span>
+              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+            </div>
           </div>
         </div>
       </nav>

--- a/docs/lib/i18n.js
+++ b/docs/lib/i18n.js
@@ -3,6 +3,8 @@ import zh from '../i18n/zh.json' with { type: 'json' };
 
 const DICTIONARIES = { en, zh };
 const SUPPORTED_LANGS = new Set(['en', 'zh']);
+const SUPPORTED_THEMES = new Set(['light', 'dark']);
+const THEME_STORAGE_KEY = 'rocket-theme';
 
 export function normalizeLang(raw) {
   if (typeof raw !== 'string' || raw.trim() === '') {
@@ -11,6 +13,15 @@ export function normalizeLang(raw) {
 
   const [base] = raw.trim().toLowerCase().split(/[-_]/);
   return SUPPORTED_LANGS.has(base) ? base : null;
+}
+
+export function normalizeTheme(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return null;
+  }
+
+  const theme = raw.trim().toLowerCase();
+  return SUPPORTED_THEMES.has(theme) ? theme : null;
 }
 
 function readCookie(name) {
@@ -57,6 +68,31 @@ export function getLang() {
   return 'en';
 }
 
+export function getTheme() {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const storedTheme = normalizeTheme(window.localStorage.getItem(THEME_STORAGE_KEY));
+    if (storedTheme) {
+      return storedTheme;
+    }
+
+    if (typeof window.matchMedia === 'function') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (prefersDark) {
+        return 'dark';
+      }
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    const docTheme = normalizeTheme(document.documentElement?.getAttribute('data-theme'));
+    if (docTheme) {
+      return docTheme;
+    }
+  }
+
+  return 'light';
+}
+
 export function setLang(code) {
   const lang = normalizeLang(code) ?? 'en';
 
@@ -76,6 +112,27 @@ export function setLang(code) {
   }
 
   return lang;
+}
+
+function applyTheme(theme, root = document) {
+  const resolvedTheme = normalizeTheme(theme) ?? 'light';
+  const documentElement = root?.documentElement ?? document?.documentElement;
+
+  if (documentElement) {
+    documentElement.setAttribute('data-theme', resolvedTheme);
+  }
+
+  return resolvedTheme;
+}
+
+export function setTheme(theme, root = document) {
+  const resolvedTheme = normalizeTheme(theme) ?? 'light';
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.setItem(THEME_STORAGE_KEY, resolvedTheme);
+  }
+
+  return applyTheme(resolvedTheme, root);
 }
 
 function lookup(lang, key) {
@@ -173,6 +230,38 @@ export function attachLanguageSwitcher(root = document) {
   });
 }
 
+function syncThemeToggle(button, theme) {
+  const isDark = theme === 'dark';
+  button.textContent = t(isDark ? 'theme.dark' : 'theme.light');
+
+  const actionLabel = t(isDark ? 'theme.switch_to_light' : 'theme.switch_to_dark');
+  button.setAttribute('aria-label', actionLabel);
+  button.setAttribute('title', actionLabel);
+  button.setAttribute('aria-pressed', String(isDark));
+}
+
+export function attachThemeToggle(root = document) {
+  if (!root || typeof root.querySelectorAll !== 'function') {
+    return;
+  }
+
+  const activeTheme = applyTheme(getTheme());
+  root.querySelectorAll('[data-theme-toggle]').forEach((button) => {
+    if (button.getAttribute('data-theme-bound') !== 'true') {
+      button.addEventListener('click', () => {
+        const nextTheme = getTheme() === 'dark' ? 'light' : 'dark';
+        const updatedTheme = setTheme(nextTheme);
+        root.querySelectorAll('[data-theme-toggle]').forEach((themeButton) => {
+          syncThemeToggle(themeButton, updatedTheme);
+        });
+      });
+      button.setAttribute('data-theme-bound', 'true');
+    }
+
+    syncThemeToggle(button, activeTheme);
+  });
+}
+
 export function initPage({ titleKey, descriptionKey } = {}) {
   if (typeof document !== 'undefined') {
     if (titleKey) {
@@ -189,4 +278,5 @@ export function initPage({ titleKey, descriptionKey } = {}) {
 
   applyTo(document);
   attachLanguageSwitcher(document);
+  attachThemeToggle(document);
 }

--- a/docs/lib/i18n.test.js
+++ b/docs/lib/i18n.test.js
@@ -3,11 +3,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyTo,
   attachLanguageSwitcher,
+  attachThemeToggle,
   formatMessage,
   getLang,
+  getTheme,
   initPage,
   normalizeLang,
+  normalizeTheme,
   setLang,
+  setTheme,
   t,
 } from './i18n.js';
 
@@ -16,14 +20,37 @@ function installGlobals({
   cookie = '',
   htmlLang = 'en',
   navigatorLanguage = 'en-US',
+  storedTheme = null,
+  prefersDark = false,
 } = {}) {
   const state = {
     cookie,
     assignedUrl: null,
+    theme: storedTheme,
+  };
+
+  const documentElementAttributes = new Map();
+  const documentElement = {
+    lang: htmlLang,
+    getAttribute(name) {
+      if (name === 'lang') {
+        return this.lang;
+      }
+
+      return documentElementAttributes.has(name) ? documentElementAttributes.get(name) : null;
+    },
+    setAttribute(name, value) {
+      if (name === 'lang') {
+        this.lang = String(value);
+        return;
+      }
+
+      documentElementAttributes.set(name, String(value));
+    },
   };
 
   const document = {
-    documentElement: { lang: htmlLang },
+    documentElement,
     title: '',
     querySelector(selector) {
       if (selector === 'meta[name="description"]') {
@@ -66,7 +93,29 @@ function installGlobals({
     },
   };
 
-  const window = { location };
+  const window = {
+    location,
+    localStorage: {
+      getItem(key) {
+        if (key !== 'rocket-theme') {
+          return null;
+        }
+
+        return state.theme;
+      },
+      setItem(key, value) {
+        if (key === 'rocket-theme') {
+          state.theme = String(value);
+        }
+      },
+    },
+    matchMedia(query) {
+      return {
+        matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
+        media: query,
+      };
+    },
+  };
   const navigator = { language: navigatorLanguage };
 
   vi.stubGlobal('document', document);
@@ -141,6 +190,10 @@ function makeRoot(elements) {
         return elements.filter((element) => element.getAttribute('data-set-lang'));
       }
 
+      if (selector === '[data-theme-toggle]') {
+        return elements.filter((element) => element.getAttribute('data-theme-toggle') !== null);
+      }
+
       return [];
     },
   };
@@ -156,6 +209,14 @@ describe('normalizeLang', () => {
     expect(normalizeLang('zh-CN')).toBe('zh');
     expect(normalizeLang('EN')).toBe('en');
     expect(normalizeLang('fr')).toBeNull();
+  });
+});
+
+describe('normalizeTheme', () => {
+  it('normalizes supported theme values', () => {
+    expect(normalizeTheme(' DARK ')).toBe('dark');
+    expect(normalizeTheme('light')).toBe('light');
+    expect(normalizeTheme('solarized')).toBeNull();
   });
 });
 
@@ -194,6 +255,35 @@ describe('setLang', () => {
   });
 });
 
+describe('getTheme', () => {
+  it('prefers stored theme values and falls back to system preference', () => {
+    installGlobals({
+      storedTheme: 'dark',
+      prefersDark: false,
+    });
+
+    expect(getTheme()).toBe('dark');
+
+    installGlobals({
+      storedTheme: null,
+      prefersDark: true,
+    });
+
+    expect(getTheme()).toBe('dark');
+  });
+});
+
+describe('setTheme', () => {
+  it('stores the theme and updates the document theme attribute', () => {
+    const { state, document } = installGlobals();
+
+    setTheme('dark');
+
+    expect(state.theme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});
+
 describe('t and formatMessage', () => {
   it('returns translated strings and interpolates placeholders', () => {
     installGlobals({
@@ -218,6 +308,7 @@ describe('initPage', () => {
   it('updates the title and meta description before applying translations', () => {
     const { document } = installGlobals({
       href: 'https://example.test/index.html?lang=zh',
+      storedTheme: 'dark',
     });
 
     initPage({
@@ -227,6 +318,7 @@ describe('initPage', () => {
 
     expect(document.title).toBe('火箭方程计算器 - 学习齐奥尔科夫斯基火箭方程');
     expect(document._description.value).toBe('通过简单计算器、解释和示例学习并探索齐奥尔科夫斯基火箭方程。');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 });
 
@@ -271,5 +363,30 @@ describe('attachLanguageSwitcher', () => {
 
     zhButton.click();
     expect(state.assignedUrl).toBe('https://example.test/compare.html?lang=zh');
+  });
+});
+
+describe('attachThemeToggle', () => {
+  it('binds click handlers, updates labels, and persists the chosen theme', () => {
+    const { state } = installGlobals({
+      href: 'https://example.test/designer-v2.html?lang=en',
+      storedTheme: 'light',
+    });
+
+    const toggleButton = makeElement();
+    toggleButton.setAttribute('data-theme-toggle', '');
+
+    const root = makeRoot([toggleButton]);
+    attachThemeToggle(root);
+
+    expect(toggleButton.textContent).toBe('Light');
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+
+    toggleButton.click();
+
+    expect(state.theme).toBe('dark');
+    expect(toggleButton.textContent).toBe('Dark');
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('true');
+    expect(toggleButton.getAttribute('aria-label')).toBe('Switch to light theme');
   });
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,19 +1,62 @@
 :root {
-  --bg: #f1f5f9;
-  --surface: #ffffff;
-  --surface-muted: #f8fafc;
-  --text: #0f172a;
-  --muted: #334155;
-  --border: #cbd5e1;
+  --bg: #dce8f8;
+  --bg-deep: #09111f;
+  --bg-ground: #102036;
+  --bg-glow: rgba(255, 255, 255, 0.72);
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-elevated: rgba(255, 255, 255, 0.94);
+  --surface-muted: rgba(241, 245, 249, 0.92);
+  --surface-strong: rgba(255, 255, 255, 0.98);
+  --text: #081225;
+  --muted: #314360;
+  --border: rgba(96, 131, 181, 0.28);
   --primary: #1d4ed8;
   --primary-hover: #1e40af;
   --focus: #f59e0b;
   --danger: #b91c1c;
-  --danger-bg: #fef2f2;
-  --danger-border: #fecaca;
-  --success: #065f46;
+  --danger-bg: #fff1f2;
+  --danger-border: #fecdd3;
+  --success: #166534;
   --success-bg: #ecfdf5;
-  --success-border: #a7f3d0;
+  --success-border: #86efac;
+  --accent-soft: #dbeafe;
+  --accent-border: #93c5fd;
+  --accent-text: #1d4ed8;
+  --accent-gradient-start: rgba(219, 234, 254, 0.96);
+  --accent-gradient-end: rgba(224, 231, 255, 0.96);
+  --shadow-md: 0 18px 36px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 28px 64px rgba(15, 23, 42, 0.16);
+  --star-opacity: 0.42;
+}
+
+:root[data-theme='dark'] {
+  --bg: #040b17;
+  --bg-deep: #08101f;
+  --bg-ground: #0d1730;
+  --bg-glow: rgba(56, 189, 248, 0.16);
+  --surface: rgba(10, 18, 34, 0.82);
+  --surface-elevated: rgba(10, 18, 34, 0.9);
+  --surface-muted: rgba(15, 23, 42, 0.92);
+  --surface-strong: rgba(17, 28, 50, 0.96);
+  --text: #e2e8f0;
+  --muted: #bfd1ee;
+  --border: rgba(148, 163, 184, 0.26);
+  --primary: #60a5fa;
+  --primary-hover: #93c5fd;
+  --danger: #fda4af;
+  --danger-bg: rgba(127, 29, 29, 0.32);
+  --danger-border: rgba(253, 164, 175, 0.28);
+  --success: #86efac;
+  --success-bg: rgba(20, 83, 45, 0.35);
+  --success-border: rgba(134, 239, 172, 0.24);
+  --accent-soft: rgba(96, 165, 250, 0.18);
+  --accent-border: rgba(147, 197, 253, 0.38);
+  --accent-text: #bfdbfe;
+  --accent-gradient-start: rgba(30, 64, 175, 0.42);
+  --accent-gradient-end: rgba(91, 33, 182, 0.36);
+  --shadow-md: 0 20px 40px rgba(2, 6, 23, 0.45);
+  --shadow-lg: 0 34px 80px rgba(2, 6, 23, 0.55);
+  --star-opacity: 0.7;
 }
 
 * {
@@ -24,6 +67,11 @@ html {
   color-scheme: light;
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+  background: var(--bg-deep);
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
 }
 
 body {
@@ -33,7 +81,34 @@ body {
   font-size: 1rem; /* 16px minimum to avoid mobile zoom */
   line-height: 1.55;
   color: var(--text);
-  background: var(--bg);
+  background:
+    radial-gradient(circle at top, var(--bg-glow), transparent 34%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-deep) 58%, var(--bg-ground) 100%);
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+body::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240' viewBox='0 0 240 240'%3E%3Cg fill='white'%3E%3Ccircle cx='22' cy='28' r='1.2'/%3E%3Ccircle cx='82' cy='46' r='1.4'/%3E%3Ccircle cx='164' cy='22' r='1.1'/%3E%3Ccircle cx='212' cy='72' r='1.3'/%3E%3Ccircle cx='42' cy='116' r='1.2'/%3E%3Ccircle cx='122' cy='102' r='1.1'/%3E%3Ccircle cx='188' cy='138' r='1.4'/%3E%3Ccircle cx='66' cy='188' r='1.1'/%3E%3Ccircle cx='154' cy='192' r='1.2'/%3E%3Ccircle cx='216' cy='182' r='1.1'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 240px 240px;
+  opacity: var(--star-opacity);
+}
+
+body::after {
+  inset: auto 0 0;
+  height: 30vh;
+  background:
+    radial-gradient(ellipse at center bottom, rgba(96, 165, 250, 0.18), transparent 58%),
+    linear-gradient(180deg, transparent 0%, rgba(8, 15, 33, 0.28) 72%, rgba(8, 15, 33, 0.5) 100%);
 }
 
 a {
@@ -61,9 +136,13 @@ footer {
 }
 
 header {
-  background: var(--surface);
+  background: var(--surface-elevated);
   border-bottom: 1px solid var(--border);
   padding: 1.25rem 1rem;
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 1;
 }
 
 header > * {
@@ -76,11 +155,15 @@ main#content {
   max-width: 70rem;
   margin: 0 auto;
   padding: 1.25rem 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 footer {
   margin-top: 1rem;
   padding: 1.25rem 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 footer > * {
@@ -130,7 +213,7 @@ code {
   font-size: 0.95em;
   padding: 0.08em 0.3em;
   border-radius: 0.35em;
-  background: #e2e8f0;
+  background: var(--surface-muted);
 }
 
 figure {
@@ -138,7 +221,8 @@ figure {
   padding: 0.75rem;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: var(--surface);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-md);
   overflow-x: auto; /* avoid horizontal page scroll if MathML is wide */
 }
 
@@ -155,20 +239,30 @@ nav ul {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  flex: 1 1 32rem;
 }
 
 nav a {
-  display: inline-block;
-  padding: 0.35rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.5rem;
+  padding: 0.35rem 0.8rem;
   border-radius: 999px;
-  background: #e2e8f0;
+  background: var(--surface-strong);
   color: var(--text);
   text-decoration: none;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
 nav a:hover {
-  background: #cbd5e1;
+  background: var(--surface-muted);
+}
+
+nav a[aria-current='page'] {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-text);
 }
 
 .nav-row {
@@ -176,53 +270,76 @@ nav a:hover {
   flex-wrap: wrap;
   gap: 0.75rem;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .nav-row ul {
   margin-top: 0;
 }
 
+.nav-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.theme-switcher,
 .lang-switcher {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  margin-top: 1rem;
+  gap: 0.45rem;
+  padding: 0.28rem 0.32rem 0.28rem 0.7rem;
+  border-radius: 999px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
 }
 
-.nav-row .lang-switcher {
-  margin-top: 0;
+.theme-switcher-label {
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
+.theme-toggle,
 .lang-switcher button {
   background: transparent;
   color: var(--text);
   border: 1px solid transparent;
-  padding: 0.2rem 0.25rem;
-  border-radius: 8px;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
   font-weight: 600;
+  min-height: auto;
 }
 
+.theme-toggle:hover,
 .lang-switcher button:hover {
-  background: #e2e8f0;
-  border-color: #d1d5db;
+  background: var(--surface-muted);
+  border-color: var(--border);
+}
+
+.theme-toggle {
+  min-width: 5.5rem;
 }
 
 .lang-switcher button.is-active {
-  background: #e2e8f0;
-  border-color: #d1d5db;
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-text);
 }
 
 .lang-switcher-separator {
   color: var(--muted);
 }
 
-
 section {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 1rem;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(16px);
 }
 
 section + section {
@@ -252,6 +369,7 @@ fieldset {
   border-radius: 14px;
   padding: 1rem;
   min-width: 0;
+  background: var(--surface-strong);
 }
 
 legend {
@@ -281,17 +399,19 @@ label {
   font-weight: 600;
 }
 
-input[type='number'] {
+input[type='number'],
+select {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 0.55rem 0.65rem;
   font-size: 1rem;
-  background: var(--surface);
+  background: var(--surface-strong);
   color: var(--text);
 }
 
-input[type='number']:focus-visible {
+input[type='number']:focus-visible,
+select:focus-visible {
   border-color: var(--primary);
 }
 
@@ -313,6 +433,8 @@ button {
   font-weight: 700;
   font-size: 1rem;
   cursor: pointer;
+  min-height: 2.75rem;
+  box-shadow: 0 12px 24px rgba(29, 78, 216, 0.18);
 }
 
 button:hover {
@@ -350,11 +472,12 @@ button:active {
 
 /* Worked example card (moved from inline styles in index.html) */
 .example-card {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
   border-radius: 12px;
   padding: 1rem;
   background: var(--surface-muted);
   max-width: 60rem;
+  box-shadow: var(--shadow-md);
 }
 
 .example-card h3 {
@@ -375,10 +498,10 @@ button:active {
 }
 
 .example-kv {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border);
   border-radius: 10px;
   padding: 0.75rem;
-  background: var(--surface);
+  background: var(--surface-strong);
 }
 
 .example-kv p {
@@ -399,4 +522,49 @@ button:active {
 
 footer small {
   color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .nav-row {
+    flex-direction: column;
+  }
+
+  .nav-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .theme-switcher,
+  .lang-switcher {
+    flex: 1 1 14rem;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 480px) {
+  header,
+  main#content,
+  footer {
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
+  }
+
+  nav ul {
+    gap: 0.4rem;
+  }
+
+  nav a {
+    width: 100%;
+    justify-content: center;
+  }
+
+  section,
+  fieldset,
+  .example-card {
+    padding: 0.85rem;
+  }
+
+  .theme-switcher-label {
+    font-size: 0.9rem;
+  }
 }


### PR DESCRIPTION
## Summary
- refresh the shared site shell with a starfield/launch-pad visual treatment
- add a persisted light/dark theme toggle across the shared header
- tighten Designer v2 mobile layout and cover theme behavior in tests

Closes #49