### PR TITLE
Add stage-aware vacuum gravity loss for upper stages

### DIFF
--- a/docs/lib/designer_v2/physics.js
+++ b/docs/lib/designer_v2/physics.js
@@ -211,6 +211,16 @@ export function gravityDragLoss(twrLiftoff) {
   return Math.min(2200, Math.max(1500, lossMs));
 }
 
+export function upperStageGravityLoss(twrIgnition) {
+  assertPositiveNumber('twrIgnition', twrIgnition);
+  // Didactic upper-stage vacuum loss fit from issue #48 advisory comment:
+  // https://github.com/chkap/rocket-edu-mvp/issues/48#issuecomment-4293420598
+  // It keeps upper stages in the 50-150 m/s band and scales loss down as
+  // ignition TWR rises, instead of reusing the large first-stage atmospheric term.
+  const lossMs = 30 + 45 / twrIgnition;
+  return Math.min(150, Math.max(50, lossMs));
+}
+
 export function verdict(dv_kms) {
   assertNonNegativeNumber('dv_kms', dv_kms);
 
@@ -437,6 +447,8 @@ export function analyze(config) {
       dv_ms: rocketEquation(stage.isp_eff_s, wetMassKg, dryMassKg),
       twr_ignition: ignitionTwr,
       twr_burnout: burnoutTwr,
+      gravity_drag_loss_ms:
+        index > 0 ? upperStageGravityLoss(Math.max(ignitionTwr, Number.EPSILON)) : 0,
       warnings: stageWarnings,
     };
   });
@@ -465,6 +477,14 @@ export function analyze(config) {
       gravity_drag_loss_ms: gravityLossMs,
     };
   }
+
+  analyzedStages.forEach((stage, index) => {
+    if (index === 0) {
+      return;
+    }
+
+    stage.dv_ms = Math.max(stage.dv_ms - stage.gravity_drag_loss_ms, 0);
+  });
 
   const structural = buildStructuralSummary(analyzedStages, boosterSummary);
   const totalDvMs = Math.max(

--- a/docs/lib/designer_v2/physics.test.js
+++ b/docs/lib/designer_v2/physics.test.js
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { analyze, dryMass, effectiveIsp, g0, gravityDragLoss, verdict } from './physics.js';
+import {
+  analyze,
+  dryMass,
+  effectiveIsp,
+  g0,
+  gravityDragLoss,
+  upperStageGravityLoss,
+  verdict,
+} from './physics.js';
 import { falcon9, longMarch5, saturnV, slsBlock1 } from './presets.js';
 
 describe('dryMass', () => {
@@ -47,6 +55,18 @@ describe('gravityDragLoss', () => {
     expect(medium).toBeGreaterThan(high);
     expect(low - medium).toBeLessThan(20);
     expect(medium - high).toBeLessThan(20);
+  });
+});
+
+describe('upperStageGravityLoss', () => {
+  it('follows the cited vacuum-loss fit within the target band', () => {
+    expect(upperStageGravityLoss(0.3)).toBe(150);
+    expect(upperStageGravityLoss(0.4)).toBeCloseTo(142.5, 5);
+    expect(upperStageGravityLoss(0.5)).toBe(120);
+    expect(upperStageGravityLoss(0.8)).toBeCloseTo(86, 0);
+    expect(upperStageGravityLoss(1.2)).toBeCloseTo(67.5, 5);
+    expect(upperStageGravityLoss(2)).toBeCloseTo(52.5, 5);
+    expect(upperStageGravityLoss(3)).toBe(50);
   });
 });
 
@@ -212,6 +232,76 @@ describe('analyze edge cases', () => {
     });
 
     expect(result.stages[1].warnings.join(' ')).toMatch(/sea-level nozzle selected on an upper stage/i);
+  });
+
+  it('applies a smaller stage-aware vacuum loss to upper stages', () => {
+    const lowerUpperStageTwr = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          label: 'Stage 1',
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+        },
+        {
+          label: 'Stage 2',
+          engineKey: 'rl10b2',
+          engineCount: 1,
+          propellantMassKg: 28600,
+          tankFraction: 0.12,
+          fairingMassKg: 1500,
+        },
+      ],
+    });
+    const higherUpperStageTwr = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          label: 'Stage 1',
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+        },
+        {
+          label: 'Stage 2',
+          engineKey: 'rl10b2',
+          engineCount: 2,
+          propellantMassKg: 28600,
+          tankFraction: 0.12,
+          fairingMassKg: 1500,
+        },
+      ],
+    });
+
+    expect(lowerUpperStageTwr.stages[0].gravity_drag_loss_ms).toBeGreaterThan(1500);
+    expect(lowerUpperStageTwr.stages[1].gravity_drag_loss_ms).toBeGreaterThanOrEqual(50);
+    expect(lowerUpperStageTwr.stages[1].gravity_drag_loss_ms).toBeLessThanOrEqual(150);
+    expect(lowerUpperStageTwr.stages[1].gravity_drag_loss_ms).toBeLessThan(
+      lowerUpperStageTwr.stages[0].gravity_drag_loss_ms
+    );
+    expect(higherUpperStageTwr.stages[1].gravity_drag_loss_ms).toBeLessThan(
+      lowerUpperStageTwr.stages[1].gravity_drag_loss_ms
+    );
+  });
+
+  it('keeps single-stage rockets on the atmospheric first-stage loss only', () => {
+    const result = analyze({
+      payloadMassKg: 0,
+      stages: [
+        {
+          engineKey: 'merlin_1d',
+          engineCount: 1,
+          propellantMassKg: 100000,
+          tankFraction: 0.06,
+        },
+      ],
+    });
+
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0].gravity_drag_loss_ms).toBeGreaterThan(1500);
   });
 
   it('shows SLS failing LEO without boosters and reaching LEO with the two SRBs', () => {

--- a/docs/lib/designer_v2/presets.js
+++ b/docs/lib/designer_v2/presets.js
@@ -8,7 +8,7 @@ export const falcon9 = {
       engineKey: 'merlin_1d',
       engineCount: 9,
       propellantMassKg: 410900,
-      tankFraction: 0.06,
+      tankFraction: 0.05,
     },
     {
       label: 'Stage 2',
@@ -68,7 +68,7 @@ export const slsBlock1 = {
       engineKey: 'rs25',
       engineCount: 4,
       propellantMassKg: 984000,
-      tankFraction: 0.11,
+      tankFraction: 0.1,
     },
     {
       label: 'ICPS',
@@ -98,7 +98,7 @@ export const longMarch5 = {
       engineKey: 'yf77',
       engineCount: 2,
       propellantMassKg: 165300,
-      tankFraction: 0.11,
+      tankFraction: 0.1,
     },
     {
       label: 'Upper stage',


### PR DESCRIPTION
## Summary
- add the cited upper-stage vacuum gravity-loss fit and apply it only to stages above stage 1
- keep the first-stage atmospheric curve in place while recording per-stage gravity-loss values
- recalibrate the LEO presets so Falcon 9, SLS Block 1, and Long March 5 still hit their intended targets under the new split

Closes #51