### PR TITLE
Fix mission target monotonicity

### DIFF
--- a/docs/lib/designer_v2/physics.js
+++ b/docs/lib/designer_v2/physics.js
@@ -264,6 +264,10 @@ export function verdict(dv_kms) {
   return match?.label ?? 'Suborbital';
 }
 
+function missionRequirementKmS(missionLabel) {
+  return VERDICT_THRESHOLDS.find((threshold) => threshold.label === missionLabel)?.min_kms ?? null;
+}
+
 function computeStageMasses(stage, options = {}) {
   const propellantMassKg = stage.propellantMassKg ?? getEngine(stage.engineKey).fixed_propellant_kg ?? 0;
   const dryMassKg = dryMass(stage, options);
@@ -554,7 +558,7 @@ export function analyze(config) {
         targetRequirementKmS !== null
           ? totalDvMs / 1000 >= targetRequirementKmS
           : typeof config.missionTarget === 'string'
-          ? verdict(totalDvMs / 1000) === config.missionTarget
+          ? totalDvMs / 1000 >= (missionRequirementKmS(config.missionTarget) ?? Number.POSITIVE_INFINITY)
           : null,
       warnings: cloneWarnings(warnings),
     },

--- a/docs/lib/designer_v2/physics.test.js
+++ b/docs/lib/designer_v2/physics.test.js
@@ -111,6 +111,7 @@ describe('analyze presets', () => {
     expect(result.total.dv_kms).toBeGreaterThan(16.15);
     expect(result.total.dv_kms).toBeLessThan(17.85);
     expect(result.total.mission_target).toBe('TLI');
+    expect(result.total.target_met).toBe(true);
   });
 
   it('keeps SLS Block 1 within 5% of the target oracle', () => {
@@ -147,6 +148,21 @@ describe('analyze edge cases', () => {
     });
 
     expect(result.total.dv_ms).toBe(0);
+  });
+
+  it('treats stronger verdicts as meeting easier named mission targets', () => {
+    const lunarCapableForTli = analyze({
+      ...saturnV,
+      missionTarget: 'TLI',
+    });
+    const gtoCapableForLeo = analyze({
+      ...saturnV,
+      missionTarget: 'LEO',
+    });
+
+    expect(lunarCapableForTli.total.verdict).toBe('Lunar landing');
+    expect(lunarCapableForTli.total.target_met).toBe(true);
+    expect(gtoCapableForLeo.total.target_met).toBe(true);
   });
 
   it('accepts max throttle on a launch stage', () => {


### PR DESCRIPTION
Closes #62

## What changed
- fix the named-mission target_met fallback to compare delivered delta-v against the selected mission threshold instead of requiring verdict label equality
- preserve existing verdict labeling while making stronger verdicts satisfy easier named targets
- add regression coverage for Saturn V at TLI and another easier-target overperformance case