### PR TITLE
Fix designer-v2 glossary translations: show translated labels instead of raw i18n keys

### DIFF
--- a/docs/designer-v2.js
+++ b/docs/designer-v2.js
@@ -225,7 +225,7 @@ function glossaryMarkup(
   } = {}
 ) {
   const term = GLOSSARY_TERM_MAP.get(termId);
-  const resolvedText = text ?? term?.labelKey ?? termId;
+  const resolvedText = text ?? t(term?.labelKey) ?? termId;
   if (!term) {
     return escapeHtml(resolvedText);
   }

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -245,6 +245,18 @@ describe('designer-v2 smoke flow', () => {
     });
   });
 
+  it('renders glossary trigger labels as translated text, not raw i18n keys', async () => {
+    await loadDesignerV2Page();
+
+    const triggers = document.querySelectorAll('#glossary-list [data-glossary-trigger]');
+    expect(triggers.length).toBeGreaterThan(0);
+
+    for (const trigger of triggers) {
+      const text = trigger.textContent.trim();
+      expect(text).not.toMatch(/^designer_v2\./);
+    }
+  });
+
   it('wires glossary tooltips into mission chips, verdict text, and live metric labels', async () => {
     await loadDesignerV2Page();
 


### PR DESCRIPTION
## Summary

The `glossaryMarkup()` function in `designer-v2.js` was using the raw `labelKey` string (e.g. `designer_v2.glossary.term.delta_v`) as visible trigger text instead of passing it through `t()` for translation. This caused all 22 glossary terms on the Flight glossary panel to display as raw dot-path i18n keys — the most visibly broken state reported in the current goal.

## Fix

One-line change on line 228: `term?.labelKey` → `t(term?.labelKey)` so the trigger text is resolved through the i18n system.

## Test added

New smoke test asserts that no glossary trigger text in `#glossary-list` starts with `designer_v2.`, preventing regressions.

## How to verify (manual)

1. Open `designer-v2.html` at **1280 px** in **light theme**, language **EN**.
2. Scroll to the **Flight glossary** panel (bottom of the left sidebar).
3. Confirm all 22 term chips show readable labels (e.g. "Δv", "Isp", "TWR", "LEO", "GEO", "GTO", "TLI", "Booster", "Fairing", "Stage", etc.) — **not** raw dot-path keys like `designer_v2.glossary.term.delta_v`.
4. Hover or focus a term chip (e.g. "Δv") and confirm the tooltip shows both a **bold label** ("Δv") and a **body description** in readable English.
5. Switch language to **中文** and repeat steps 2–4. Confirm chips show Chinese labels (e.g. "助推器", "整流罩", "级") and tooltip bodies are in Chinese.
6. Switch to **dark theme** and confirm the glossary renders correctly in both EN and 中文.
7. Resize viewport to **768 px** (tablet) and **375 px** (mobile). Confirm all glossary chips remain readable, no raw keys visible, no layout breakage.
8. Open browser console and confirm no `[i18n] Missing key:` warnings for any `designer_v2.glossary.*` keys.
9. Spot-check the rest of the page for any remaining visible dot-path strings containing `designer_v2.glossary`.

## Automated verification

- All 60 tests pass (59 existing + 1 new regression test).
- EN and ZH glossary key sets are identical (46 keys each) — no parity gap.

Pre-push self-check passed: `8f063bf`, files: `docs/designer-v2.js`, `docs/designer-v2.smoke.test.js`.

Closes #90