### PR TITLE
Make designer-v2 engine and booster cards look intentionally complete

### DIFF
--- a/docs/designer-v2.css
+++ b/docs/designer-v2.css
@@ -458,6 +458,16 @@
   font-weight: 800;
 }
 
+.designer-v2-engine-stats-note {
+  grid-column: 1 / -1;
+  padding: 0.6rem 0.8rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
 .designer-v2-hidden {
   display: none !important;
 }

--- a/docs/designer-v2.js
+++ b/docs/designer-v2.js
@@ -1319,6 +1319,19 @@ function engineSpotlightMarkup(engine, panelId) {
     return '';
   }
 
+  const vacuumOnly = engine.thrust_sl_kN === 0 || engine.isp_sl === 0;
+
+  const seaLevelRows = vacuumOnly
+    ? `<div class="designer-v2-engine-stats-note"><dd>${t('designer_v2.engine_card.sea_level_na')}</dd></div>`
+    : `<div>
+            <dt>${t('designer_v2.engine_card.thrust_sea_level')}</dt>
+            <dd>${formatStatValue(engine.thrust_sl_kN, 'kN')}</dd>
+          </div>
+          <div>
+            <dt>${withGlossaryTerm(t('designer_v2.engine_card.isp_sea_level'), 'sea-level-isp')}</dt>
+            <dd>${formatStatValue(engine.isp_sl, 's', 0)}</dd>
+          </div>`;
+
   return `
     <section class="designer-v2-engine-card" aria-labelledby="${panelId}-title" data-engine-panel="${engine.key}">
       <div class="designer-v2-engine-card-copy">
@@ -1331,17 +1344,10 @@ function engineSpotlightMarkup(engine, panelId) {
       <div class="designer-v2-engine-card-body">
         ${engineSpotlightIllustration(engine, panelId)}
         <dl class="designer-v2-engine-stats">
-          <div>
-            <dt>${t('designer_v2.engine_card.thrust_sea_level')}</dt>
-            <dd>${formatStatValue(engine.thrust_sl_kN, 'kN')}</dd>
-          </div>
+          ${seaLevelRows}
           <div>
             <dt>${t('designer_v2.engine_card.thrust_vacuum')}</dt>
             <dd>${formatStatValue(engine.thrust_vac_kN, 'kN')}</dd>
-          </div>
-          <div>
-            <dt>${withGlossaryTerm(t('designer_v2.engine_card.isp_sea_level'), 'sea-level-isp')}</dt>
-            <dd>${formatStatValue(engine.isp_sl, 's', 0)}</dd>
           </div>
           <div>
             <dt>${withGlossaryTerm(t('designer_v2.engine_card.isp_vacuum'), 'vacuum-isp')}</dt>
@@ -1567,9 +1573,9 @@ function boosterCardMarkup(analysis) {
     <article class="designer-v2-card" aria-labelledby="booster-title">
       <div class="designer-v2-card-header">
         <div>
-          <p class="designer-v2-card-role">${withGlossaryTerm(t('designer_v2.card.parallel_boosters'), 'booster')}</p>
+          <p class="designer-v2-card-role">${glossaryInlineMarkup('booster', t('designer_v2.card.parallel_boosters'))}</p>
           <h3 id="booster-title">${
-            withGlossaryTerm(boosters.nameKey ? t(boosters.nameKey) : t('designer_v2.card.boosters'), 'booster')
+            glossaryInlineMarkup('booster', boosters.nameKey ? t(boosters.nameKey) : t('designer_v2.card.boosters'))
           }</h3>
         </div>
       </div>

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -406,4 +406,37 @@ describe('designer-v2 smoke flow', () => {
     });
   });
 
+  it('shows "Sea-level data not applicable" for vacuum-only engines instead of dashes', async () => {
+    await loadDesignerV2Page();
+
+    // Falcon 9 preset gives us a 2-stage rocket with merlin_vac on stage 1
+    const presetSelect = document.getElementById('preset-select');
+    presetSelect.value = 'falcon9';
+    presetSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    await waitFor(() => {
+      const panel = document.querySelector('[data-engine-panel="merlin_vac"]');
+      expect(panel).not.toBeNull();
+      expect(panel?.textContent).toContain('Sea-level data not applicable');
+      expect(panel?.querySelector('.designer-v2-engine-stats-note')).not.toBeNull();
+    });
+  });
+
+  it('renders booster heading as one clean string without stray trailing characters', async () => {
+    await loadDesignerV2Page();
+
+    const boosterTitle = document.getElementById('booster-title');
+    expect(boosterTitle).not.toBeNull();
+    const trigger = boosterTitle.querySelector('[data-glossary-trigger="booster"]');
+    expect(trigger).not.toBeNull();
+    expect(trigger.textContent.trim()).toBe('Boosters');
+    // No stray text nodes outside the glossary item
+    const glossaryItem = boosterTitle.querySelector('[data-glossary-item="booster"]');
+    const siblingText = Array.from(boosterTitle.childNodes)
+      .filter((n) => n !== glossaryItem && n.nodeType === 3)
+      .map((n) => n.textContent.trim())
+      .join('');
+    expect(siblingText).toBe('');
+  });
+
 });

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -342,5 +342,6 @@
   "designer_v2.preset.long_march_5.boosters": "Boosters",
   "designer_v2.footer.prefix": "Advanced rocket designer ·",
   "designer_v2.target.gto": "GTO (11.8 km/s)",
-  "designer_v2.target.tli": "TLI (12.4 km/s)"
+  "designer_v2.target.tli": "TLI (12.4 km/s)",
+  "designer_v2.engine_card.sea_level_na": "Sea-level data not applicable"
 }

--- a/docs/i18n/zh.json
+++ b/docs/i18n/zh.json
@@ -342,5 +342,6 @@
   "designer_v2.preset.long_march_5.boosters": "助推器",
   "designer_v2.footer.prefix": "高级火箭设计器 ·",
   "designer_v2.target.gto": "GTO（11.8 km/s）",
-  "designer_v2.target.tli": "TLI（12.4 km/s）"
+  "designer_v2.target.tli": "TLI（12.4 km/s）",
+  "designer_v2.engine_card.sea_level_na": "海平面数据不适用"
 }


### PR DESCRIPTION
## Summary

Two focused fixes for the engine spotlight and booster card areas on `designer-v2.html`:

### 1. Engine spotlight: hide N/A sea-level rows
For vacuum-only engines (where `thrust_sl_kN=0` or `isp_sl=0`), the card previously showed `—` for sea-level thrust and Isp — making it look half-loaded. Now it replaces those rows with a single "Sea-level data not applicable" note, while vacuum stats display normally.

### 2. Booster heading: fix "Booster s" pluralization
`withGlossaryTerm("Boosters", "booster")` does a substring match on the glossary label "Booster" inside "Boosters", wrapping only the first 7 characters and leaving a stray `s` as a bare text node. Replaced with `glossaryInlineMarkup("booster", "Boosters")` which wraps the complete text as the trigger label.

### Supporting changes
- Added `designer_v2.engine_card.sea_level_na` i18n key in EN ("Sea-level data not applicable") and ZH ("海平面数据不适用")
- Added `.designer-v2-engine-stats-note` CSS class (full-width italic note)
- EN/ZH key parity confirmed (345 keys each)

## How to verify (manual)

1. Open `designer-v2.html` at **1280 px**, light theme, EN.
2. Load **Falcon 9** preset. The upper-stage engine card (Merlin Vacuum) should show "Sea-level data not applicable" instead of two `—` rows.
3. Switch to **SLS Block 1** preset. The SRB booster card should show real values where catalog data exists. The booster heading should read "SRB" (from preset nameKey), not "Booster s" or "SRB s".
4. Load **Custom** config. The booster card heading should read "Boosters" as one clean word — no trailing `s` as a separate element.
5. Check at **768 px** and **375 px** — cards remain readable, no layout breakage.
6. Switch to **中文** and **dark theme** — repeat checks.
7. Open browser console — no `[i18n] Missing key:` warnings.

## Automated verification

- All 62 tests pass (60 existing + 2 new: vacuum-only engine note, booster heading integrity).

Pre-push self-check passed: `67c2ec5`, files: `docs/designer-v2.css`, `docs/designer-v2.js`, `docs/designer-v2.smoke.test.js`, `docs/i18n/en.json`, `docs/i18n/zh.json`.

Closes #92