### PR TITLE
Fix shared header bar and page-title wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .agents/log
 .agents/cfg/
 .agents/.lock
+node_modules/

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -439,4 +439,35 @@ describe('designer-v2 smoke flow', () => {
     expect(siblingText).toBe('');
   });
 
+  it('renders the header bar with H1, nav, theme toggle, and language toggle', async () => {
+    await loadDesignerV2Page();
+
+    const header = document.querySelector('header');
+    expect(header).not.toBeNull();
+
+    const h1 = header.querySelector('h1');
+    expect(h1).not.toBeNull();
+    expect(h1.textContent.length).toBeGreaterThan(0);
+
+    const navRow = header.querySelector('.nav-row');
+    expect(navRow).not.toBeNull();
+
+    const navLinks = navRow.querySelectorAll('nav ul a, ul a');
+    expect(navLinks.length).toBeGreaterThanOrEqual(2);
+
+    const themeToggle = header.querySelector('[data-theme-toggle]');
+    expect(themeToggle).not.toBeNull();
+    expect(themeToggle.classList.contains('is-active')).toBe(true);
+
+    const langSwitcher = header.querySelector('.lang-switcher');
+    expect(langSwitcher).not.toBeNull();
+    const langButtons = langSwitcher.querySelectorAll('button');
+    expect(langButtons.length).toBe(2);
+
+    const navControls = header.querySelector('.nav-controls');
+    expect(navControls).not.toBeNull();
+    expect(navControls.querySelector('.theme-switcher')).not.toBeNull();
+    expect(navControls.querySelector('.lang-switcher')).not.toBeNull();
+  });
+
 });

--- a/docs/lib/i18n.js
+++ b/docs/lib/i18n.js
@@ -238,6 +238,7 @@ function syncThemeToggle(button, theme) {
   button.setAttribute('aria-label', actionLabel);
   button.setAttribute('title', actionLabel);
   button.setAttribute('aria-pressed', String(isDark));
+  button.classList.toggle('is-active', true);
 }
 
 export function attachThemeToggle(root = document) {

--- a/docs/lib/i18n.test.js
+++ b/docs/lib/i18n.test.js
@@ -390,6 +390,7 @@ describe('attachThemeToggle', () => {
 
     expect(toggleButton.textContent).toBe('Light');
     expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+    expect(toggleButton.classList.contains('is-active')).toBe(true);
 
     toggleButton.click();
 
@@ -397,5 +398,6 @@ describe('attachThemeToggle', () => {
     expect(toggleButton.textContent).toBe('Dark');
     expect(toggleButton.getAttribute('aria-pressed')).toBe('true');
     expect(toggleButton.getAttribute('aria-label')).toBe('Switch to light theme');
+    expect(toggleButton.classList.contains('is-active')).toBe(true);
   });
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -179,7 +179,7 @@ header {
   box-shadow: var(--shadow-lg);
   position: relative;
   z-index: 1;
-  overflow: hidden;
+  overflow: visible;
 }
 
 header::after {
@@ -234,7 +234,6 @@ h1 {
   line-height: 1.05;
   letter-spacing: -0.03em;
   margin: 0 0 0.35rem 0;
-  max-width: 12ch;
 }
 
 @media (min-width: 768px) {
@@ -289,11 +288,11 @@ figcaption {
 nav ul {
   list-style: none;
   padding: 0;
-  margin: 1rem 0 0;
+  margin: 0.6rem 0 0;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  flex: 1 1 32rem;
+  flex: 1 1 auto;
 }
 
 nav a {
@@ -328,7 +327,7 @@ nav a[aria-current='page'] {
   flex-wrap: wrap;
   gap: 0.75rem;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .nav-row ul {
@@ -382,6 +381,12 @@ nav a[aria-current='page'] {
 }
 
 .lang-switcher button.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-text);
+}
+
+.theme-toggle.is-active {
   background: var(--accent-soft);
   border-color: var(--accent-border);
   color: var(--accent-text);
@@ -622,7 +627,7 @@ footer small {
 
 header > p {
   max-width: 42rem;
-  margin: 0;
+  margin: 0 0 0.15rem 0;
   color: var(--muted);
   font-size: 1.02rem;
 }


### PR DESCRIPTION
## Summary

Closes #93

Rebuilds the shared header bar across `/`, `designer.html`, and `designer-v2.html` so the title no longer wraps one word per line and all header controls sit in a cohesive bar.

## Changes

### CSS (`docs/style.css`)
- **Removed `max-width: 12ch` from h1** — this was the root cause of the homepage H1 breaking into 6 single-word lines. Titles now flow naturally within the 70rem container.
- **Changed header `overflow: hidden` → `overflow: visible`** — prevents clipping of any header elements.
- **Tightened nav layout**: reduced `nav ul` top margin from 1rem → 0.6rem, changed flex-basis from `32rem` → `auto` for better wrapping.
- **Aligned nav-row `align-items: center`** (was `flex-start`) so nav links and controls sit on the same baseline.
- **Added subtitle bottom margin** (0.15rem) for better visual separation.
- **Added `.theme-toggle.is-active` CSS** matching the lang-switcher's accent-soft/accent-border treatment so both controls share the same visual family.

### JS (`docs/lib/i18n.js`)
- Added `button.classList.toggle('is-active', true)` in `syncThemeToggle()` so the theme toggle button gets the same visual treatment as the active language button.

### Tests
- Added `is-active` assertions to the existing theme toggle unit test.
- Added a new smoke test verifying the header bar contains: h1, nav-row, theme toggle with is-active, language switcher with 2 buttons, and nav-controls grouping.

### Housekeeping
- Added `node_modules/` to `.gitignore`.

## How to verify (manual)
1. Open `/` at 1280 px — confirm the H1 fits on ≤2 lines (no more one-word-per-line).
2. Reduce to 375 px — confirm H1 stays within ≤3 lines with readable line height.
3. Repeat the title check on `designer.html` and `designer-v2.html`.
4. On all three pages, confirm title, nav, theme toggle, and language toggle sit together in a single header region with no large dead gap.
5. Toggle theme — confirm the theme button has the same pill accent styling as the active language button.
6. Toggle language and repeat checks at 768 px and 375 px.

Pre-push self-check passed: 8fc17c0, .gitignore docs/designer-v2.smoke.test.js docs/lib/i18n.js docs/lib/i18n.test.js docs/style.css