### PR TITLE
Finish cross-page typography, contrast, and focus-state polish

### DIFF
--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -470,4 +470,24 @@ describe('designer-v2 smoke flow', () => {
     expect(navControls.querySelector('.lang-switcher')).not.toBeNull();
   });
 
+  it('includes accessible focus and contrast CSS rules', async () => {
+    const cssPath = path.join(docsDir, 'style.css');
+    const css = await fs.readFile(cssPath, 'utf-8');
+
+    // Focus ring defined for interactive elements
+    expect(css).toContain('a:focus-visible');
+    expect(css).toContain('button:focus-visible');
+    expect(css).toContain('select:focus-visible');
+    expect(css).toContain('outline: 3px solid var(--focus)');
+
+    // Dark theme overrides focus color for visibility
+    expect(css).toMatch(/\[data-theme=['"]dark['"]\][\s\S]*--focus:\s*#fbbf24/);
+
+    // Footer links have explicit styling
+    expect(css).toContain('footer a');
+
+    // Display math has centered block styling
+    expect(css).toContain("math[display='block']");
+  });
+
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -12,11 +12,12 @@
   --surface-muted: rgba(241, 245, 249, 0.92);
   --surface-strong: rgba(255, 255, 255, 0.98);
   --text: #081225;
-  --muted: #314360;
+  --muted: #283a54;
   --border: rgba(96, 131, 181, 0.28);
   --primary: #1d4ed8;
   --primary-hover: #1e40af;
   --focus: #f59e0b;
+  --focus-dark: #fbbf24;
   --danger: #b91c1c;
   --danger-bg: #fff1f2;
   --danger-border: #fecdd3;
@@ -64,6 +65,7 @@
   --accent-gradient-end: rgba(91, 33, 182, 0.36);
   --shadow-md: 0 20px 40px rgba(2, 6, 23, 0.45);
   --shadow-lg: 0 34px 80px rgba(2, 6, 23, 0.55);
+  --focus: #fbbf24;
   --star-opacity: 0.7;
 }
 
@@ -267,6 +269,17 @@ code {
   padding: 0.08em 0.3em;
   border-radius: 0.35em;
   background: var(--surface-muted);
+}
+
+code sub {
+  font-size: 0.8em;
+}
+
+math[display='block'] {
+  display: block;
+  text-align: center;
+  font-size: 1.35rem;
+  margin: 0.6rem 0;
 }
 
 figure {
@@ -500,6 +513,8 @@ select {
 input[type='number']:focus-visible,
 select:focus-visible {
   border-color: var(--primary);
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
   box-shadow:
     0 0 0 4px color-mix(in srgb, var(--primary) 18%, transparent),
     inset 0 1px 2px rgba(15, 23, 42, 0.04);
@@ -623,6 +638,15 @@ button:active {
 
 footer small {
   color: var(--muted);
+}
+
+footer a {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+footer a:hover {
+  color: var(--primary-hover);
 }
 
 header > p {


### PR DESCRIPTION
## Summary

Closes #94

Final visual polish pass: raises contrast for muted text, brightens focus rings in dark theme, unifies inline math styling, and ensures keyboard focus indicators are consistent across all interactive elements.

## Changes

### Contrast (`docs/style.css`)
- **Darkened `--muted`** from `#314360` → `#283a54` in light theme — raises contrast ratio on the `--bg` (#dce8f8) background from ~7.3:1 to ~9:1 for footer text and subtitles.
- **Added explicit footer link styling** — `footer a` now uses `var(--primary)` with `font-weight: 600` and hover state, ensuring links are clearly distinct from surrounding muted text.

### Focus States
- **Brighter dark-theme focus ring** — added `--focus: #fbbf24` override in `:root[data-theme='dark']` (was inheriting #f59e0b from light theme). The brighter amber provides better visibility on dark surfaces.
- **Added outline ring to `select:focus-visible`** — previously only changed border-color. Now gets the same `outline: 3px solid var(--focus)` treatment as links, buttons, and inputs.

### Inline Math Typography
- **Added `math[display='block']` styling** — centered display layout with `font-size: 1.35rem` for the MathML equation block.
- **Added `code sub` sizing** — `font-size: 0.8em` ensures subscripts in inline code equations (e.g., `m₀`, `v_e`) are consistently sized.

### Tests
- Added smoke test verifying: focus-visible rules exist for a/button/select, dark theme focus color override, footer link styling, display math styling.

## How to verify (manual)
1. Open each page in light theme — confirm footer text and subtitle ("Learn how mass…") are visibly readable (darker than before).
2. Check footer links are styled with primary color and bold weight.
3. Tab through interactive elements in **dark theme** — confirm amber focus ring is clearly visible on buttons, links, nav pills, and the preset select.
4. On `index.html`, confirm the display MathML equation is centered and the inline `<code>` equations have consistent subscript sizing.
5. Repeat at 375px and 768px in both EN and 中文.

Pre-push self-check passed: b8d4af1, docs/designer-v2.smoke.test.js docs/style.css