### PR TITLE
fix(designer-v2): mission ladder marker overlap & TLI badge collision

### DIFF
--- a/docs/designer-v2.js
+++ b/docs/designer-v2.js
@@ -32,7 +32,7 @@ export const MISSION_MARKERS = [
   { id: 'meo', labelKey: 'designer_v2.target.meo', glossaryId: 'orbit-meo', altitudeKm: 2000, badge: 'M' },
   { id: 'geo', labelKey: 'designer_v2.target.geo', glossaryId: 'orbit-geo', altitudeKm: 35786, badge: 'G' },
   { id: 'gto', labelKey: 'designer_v2.target.gto', glossaryId: 'orbit-gto', fixedThresholdKmS: 11.8, badge: 'T' },
-  { id: 'tli', labelKey: 'designer_v2.target.tli', glossaryId: 'orbit-tli', fixedThresholdKmS: 12.4, badge: 'U' },
+  { id: 'tli', labelKey: 'designer_v2.target.tli', glossaryId: 'orbit-tli', fixedThresholdKmS: 12.4, badge: 'N' },
 ].map((marker) => ({
   ...marker,
   thresholdKmS: marker.fixedThresholdKmS ?? targetOrbitRequirementKmS(marker.altitudeKm),
@@ -1744,13 +1744,16 @@ function renderMetricContainers(result = null) {
   }
 }
 
+const MISSION_PROGRESS_MAX_KMS = Math.max(
+  ...MISSION_MARKERS.map((marker) => marker.thresholdKmS),
+);
+
 export function missionProgressPercent(deltaVKmS) {
-  const max = MISSION_MARKERS[MISSION_MARKERS.length - 1].thresholdKmS;
   if (!Number.isFinite(deltaVKmS) || deltaVKmS <= 0) {
     return 0;
   }
 
-  return Math.min((deltaVKmS / max) * 100, 100);
+  return Math.min((deltaVKmS / MISSION_PROGRESS_MAX_KMS) * 100, 100);
 }
 
 function translatedVerdict(rawVerdict) {

--- a/docs/designer-v2.test.js
+++ b/docs/designer-v2.test.js
@@ -34,11 +34,11 @@ describe('designer-v2 helpers', () => {
   });
 
   it('maps mission progress to the marker bar scale', () => {
+    const maxThreshold = Math.max(...MISSION_MARKERS.map((m) => m.thresholdKmS));
     expect(missionProgressPercent(0)).toBe(0);
-    expect(missionProgressPercent(MISSION_MARKERS[MISSION_MARKERS.length - 1].thresholdKmS)).toBe(100);
-    expect(
-      missionProgressPercent(MISSION_MARKERS[MISSION_MARKERS.length - 1].thresholdKmS / 2)
-    ).toBeCloseTo(50, 1);
+    expect(missionProgressPercent(maxThreshold)).toBe(100);
+    expect(missionProgressPercent(maxThreshold * 2)).toBe(100);
+    expect(missionProgressPercent(maxThreshold / 2)).toBeCloseTo(50, 1);
   });
 
   it('loads preset drafts into analyze-compatible configs', () => {


### PR DESCRIPTION
## Bugs

Browser DOM inspection of the live mission ladder showed two issues missed by Pack E's verifier:

1. **Marker overlap at right edge.** `missionProgressPercent` used `MISSION_MARKERS[last].thresholdKmS` as the bar's max — but TLI's fixed 12.4 km/s threshold is **less** than GEO's 13.33 km/s. GEO's percent clamped to 100, landing on the same pixel as TLI. Real DOM left values pre-fix:
   - LEO 75.8% / ISS 76.7% / MEO 82.9% / **GEO 100%** / GTO 95.2% / **TLI 100%**
2. **TLI badge displayed 'U'** instead of a meaningful glyph, while GTO already owned 'T'. Confusing for users.

## Fix

- Compute `MISSION_PROGRESS_MAX_KMS = Math.max(...thresholds)` once, use it as the scale denominator. Future marker re-orderings won't break.
- TLI badge `U` → `N` (tra**N**s-lunar).
- Test now asserts against the real max + pins the clamp behavior for inputs above max (previously the test enshrined the bug).

## Verify

- `npm test`: 64/64 ✅
- New marker positions: LEO 70.5 / ISS 71.3 / MEO 77.3 / GTO 88.5 / TLI 93.0 / GEO 100 — no overlap