### PR TITLE
fix(css): respect hidden on glossary tooltips

### DIFF
--- a/docs/designer-v2.css
+++ b/docs/designer-v2.css
@@ -88,6 +88,10 @@
   color: inherit;
 }
 
+.designer-v2-glossary-tooltip[hidden] {
+  display: none !important;
+}
+
 .designer-v2-glossary-tooltip {
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
## Bug
On desktop, all 6 mission-ladder glossary tooltips rendered simultaneously, stacked on top of each other.

## Root Cause
`.designer-v2-glossary-tooltip` set `position: absolute` (and other layout props) but never declared `display: none` for the `[hidden]` state. The UA stylesheet's `[hidden]{display:none}` is the lowest specificity, so any class-level rule that touches display context wins. Tooltips had `hidden=""` attribute correctly, but rendered with computed `display: block`.

## Fix
Add `.designer-v2-glossary-tooltip[hidden] { display: none !important; }` before the base rule.

## Verify
- 64/64 tests pass
- Manual: open designer-v2.html, mission ladder shows no floating tooltips; clicking a marker still toggles its tooltip