### PR TITLE
Unify shared site header across all pages

### DIFF
--- a/docs/designer-v2.html
+++ b/docs/designer-v2.html
@@ -13,33 +13,13 @@
     <script type="module" src="./designer-v2.js"></script>
   </head>
   <body>
-    <header>
-      <h1 data-i18n="designer_v2.hero.title"></h1>
-      <p data-i18n="designer_v2.hero.subtitle"></p>
-
-      <nav aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
-        <div class="nav-row">
-          <ul>
-            <li><a href="./index.html" data-i18n="nav.index"></a></li>
-            <li><a href="./designer.html" data-i18n="nav.designer"></a></li>
-            <li><a href="./designer-v2.html" aria-current="page" data-i18n="nav.designer_v2"></a></li>
-          </ul>
-          <div class="nav-controls">
-            <div class="theme-switcher">
-              <span class="theme-switcher-label" data-i18n="theme.label"></span>
-              <button type="button" class="theme-toggle" data-theme-toggle></button>
-            </div>
-            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-              <span class="lang-switcher-separator">|</span>
-              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
-            </div>
-          </div>
-        </div>
-      </nav>
-    </header>
 
     <main id="content" class="designer-v2-page">
+      <div class="page-hero">
+        <h1 data-i18n="designer_v2.hero.title"></h1>
+        <p data-i18n="designer_v2.hero.subtitle"></p>
+      </div>
+
       <div class="designer-v2-layout">
         <div class="designer-v2-main">
         <section aria-labelledby="designer-v2-intro-title">

--- a/docs/designer-v2.js
+++ b/docs/designer-v2.js
@@ -4,6 +4,7 @@ import {
   targetOrbitRequirementKmS,
 } from './lib/designer_v2/physics.js';
 import { PRESETS } from './lib/designer_v2/presets.js';
+import './site-header.js';
 import { formatMessage, initPage, t } from './lib/i18n.js';
 
 const MAX_STAGES = 4;

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -439,21 +439,32 @@ describe('designer-v2 smoke flow', () => {
     expect(siblingText).toBe('');
   });
 
-  it('renders the header bar with H1, nav, theme toggle, and language toggle', async () => {
+  it('renders unified header with site title, nav, theme toggle, and language toggle', async () => {
     await loadDesignerV2Page();
 
     const header = document.querySelector('header');
     expect(header).not.toBeNull();
 
-    const h1 = header.querySelector('h1');
+    // Site title link
+    const siteTitle = header.querySelector('.site-title');
+    expect(siteTitle).not.toBeNull();
+    expect(siteTitle.getAttribute('href')).toBe('./index.html');
+
+    // Page hero H1 is in main, not header
+    const h1 = document.querySelector('.page-hero h1');
     expect(h1).not.toBeNull();
     expect(h1.textContent.length).toBeGreaterThan(0);
 
     const navRow = header.querySelector('.nav-row');
     expect(navRow).not.toBeNull();
 
-    const navLinks = navRow.querySelectorAll('nav ul a, ul a');
-    expect(navLinks.length).toBeGreaterThanOrEqual(2);
+    // Unified nav has 4 links (index, designer, designer-v2, glossary)
+    const navLinks = navRow.querySelectorAll('ul a');
+    expect(navLinks.length).toBe(4);
+
+    // Active page is marked
+    const activePage = navRow.querySelector('a[aria-current="page"]');
+    expect(activePage).not.toBeNull();
 
     const themeToggle = header.querySelector('[data-theme-toggle]');
     expect(themeToggle).not.toBeNull();

--- a/docs/designer.html
+++ b/docs/designer.html
@@ -13,33 +13,13 @@
     <script type="module" src="./designer.js"></script>
   </head>
   <body>
-    <header>
-      <h1 data-i18n="designer.hero.title"></h1>
-      <p data-i18n="designer.hero.subtitle"></p>
-
-      <nav aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
-        <div class="nav-row">
-          <ul>
-            <li><a href="./index.html" data-i18n="nav.index"></a></li>
-            <li><a href="./designer.html" aria-current="page" data-i18n="nav.designer"></a></li>
-            <li><a href="./designer-v2.html" data-i18n="nav.designer_v2"></a></li>
-          </ul>
-          <div class="nav-controls">
-            <div class="theme-switcher">
-              <span class="theme-switcher-label" data-i18n="theme.label"></span>
-              <button type="button" class="theme-toggle" data-theme-toggle></button>
-            </div>
-            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-              <span class="lang-switcher-separator">|</span>
-              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
-            </div>
-          </div>
-        </div>
-      </nav>
-    </header>
 
     <main id="content">
+      <div class="page-hero">
+        <h1 data-i18n="designer.hero.title"></h1>
+        <p data-i18n="designer.hero.subtitle"></p>
+      </div>
+
       <section aria-labelledby="designer-intro-title">
         <h2 id="designer-intro-title" data-i18n="designer.intro.title"></h2>
         <p data-i18n="designer.intro.body"></p>

--- a/docs/designer.js
+++ b/docs/designer.js
@@ -5,6 +5,7 @@ import {
   stageDeltaV,
   validateStage,
 } from './lib/rocket.js';
+import './site-header.js';
 import { formatMessage, initPage, t } from './lib/i18n.js';
 
 const MIN_STAGES = 1;

--- a/docs/glossary.css
+++ b/docs/glossary.css
@@ -1,0 +1,115 @@
+.glossary-section {
+  grid-column: 1 / -1;
+}
+
+.glossary-search-wrapper {
+  margin-bottom: 1rem;
+}
+
+.glossary-search {
+  width: 100%;
+  max-width: 28rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-strong);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.glossary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.97rem;
+}
+
+.glossary-table thead th {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 2px solid var(--border);
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
+}
+
+.glossary-table tbody tr {
+  border-bottom: 1px solid var(--border);
+}
+
+.glossary-table tbody tr[hidden] {
+  display: none !important;
+}
+
+.glossary-table td {
+  padding: 0.65rem 0.75rem;
+  vertical-align: top;
+}
+
+.glossary-term-cell {
+  white-space: nowrap;
+  width: 10rem;
+}
+
+.glossary-def-cell {
+  line-height: 1.55;
+}
+
+.glossary-cat-cell {
+  width: 7rem;
+}
+
+.glossary-category-badge {
+  display: inline-block;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: var(--surface-muted);
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.glossary-cat-equation {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  border-color: var(--accent-border);
+}
+
+.glossary-cat-orbit {
+  background: var(--success-bg);
+  color: var(--success);
+  border-color: var(--success-border);
+}
+
+.glossary-cat-performance {
+  background: rgba(245, 158, 11, 0.12);
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+:root[data-theme='dark'] .glossary-cat-performance {
+  color: #fbbf24;
+}
+
+@media (max-width: 720px) {
+  .glossary-term-cell {
+    white-space: normal;
+    width: auto;
+  }
+
+  .glossary-cat-cell {
+    width: auto;
+  }
+
+  .glossary-table {
+    font-size: 0.92rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .glossary-table td,
+  .glossary-table th {
+    padding: 0.5rem 0.4rem;
+  }
+}

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Quick reference for all the terms used across the rocket design tools."
+    />
+    <title>Flight Glossary</title>
+    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./glossary.css" />
+    <script type="module" src="./glossary.js"></script>
+  </head>
+  <body>
+
+    <main id="content">
+      <div class="page-hero">
+        <h1 data-i18n="glossary.title"></h1>
+        <p data-i18n="glossary.subtitle"></p>
+      </div>
+
+      <section class="glossary-section" aria-labelledby="glossary-heading">
+        <div class="glossary-search-wrapper">
+          <input
+            type="search"
+            id="glossary-search"
+            class="glossary-search"
+            data-i18n="glossary.search_placeholder"
+            data-i18n-attr="placeholder"
+            autocomplete="off"
+          />
+        </div>
+
+        <table class="glossary-table" id="glossary-table">
+          <thead>
+            <tr>
+              <th data-i18n="glossary.col.term"></th>
+              <th data-i18n="glossary.col.definition"></th>
+              <th data-i18n="glossary.col.category"></th>
+            </tr>
+          </thead>
+          <tbody id="glossary-tbody">
+            <!-- Rows injected by glossary.js -->
+          </tbody>
+        </table>
+      </section>
+    </main>
+
+    <footer>
+      <small>
+        <span data-i18n="glossary.subtitle"></span>
+      </small>
+    </footer>
+  </body>
+</html>

--- a/docs/glossary.js
+++ b/docs/glossary.js
@@ -1,0 +1,74 @@
+import './site-header.js';
+import { initPage, t } from './lib/i18n.js';
+
+const GLOSSARY_TERMS = [
+  { id: 'delta-v', termKey: 'designer_v2.glossary.term.delta_v', bodyKey: 'designer_v2.glossary.body.delta_v', category: 'equation' },
+  { id: 'isp', termKey: 'designer_v2.glossary.term.isp', bodyKey: 'designer_v2.glossary.body.isp', category: 'equation' },
+  { id: 'twr', termKey: 'designer_v2.glossary.term.twr', bodyKey: 'designer_v2.glossary.body.twr', category: 'performance' },
+  { id: 'mr', termKey: 'designer_v2.glossary.term.mr', bodyKey: 'designer_v2.glossary.body.mr', category: 'equation' },
+  { id: 'stage', termKey: 'designer_v2.glossary.term.stage', bodyKey: 'designer_v2.glossary.body.stage', category: 'stage' },
+  { id: 'booster', termKey: 'designer_v2.glossary.term.booster', bodyKey: 'designer_v2.glossary.body.booster', category: 'stage' },
+  { id: 'fairing', termKey: 'designer_v2.glossary.term.fairing', bodyKey: 'designer_v2.glossary.body.fairing', category: 'stage' },
+  { id: 'vacuum-isp', termKey: 'designer_v2.glossary.term.vacuum_isp', bodyKey: 'designer_v2.glossary.body.vacuum_isp', category: 'performance' },
+  { id: 'sea-level-isp', termKey: 'designer_v2.glossary.term.sea_level_isp', bodyKey: 'designer_v2.glossary.body.sea_level_isp', category: 'performance' },
+  { id: 'specific-impulse', termKey: 'designer_v2.glossary.term.specific_impulse', bodyKey: 'designer_v2.glossary.body.specific_impulse', category: 'equation' },
+  { id: 'mass-ratio', termKey: 'designer_v2.glossary.term.mass_ratio', bodyKey: 'designer_v2.glossary.body.mass_ratio', category: 'equation' },
+  { id: 'burn-time', termKey: 'designer_v2.glossary.term.burn_time', bodyKey: 'designer_v2.glossary.body.burn_time', category: 'performance' },
+  { id: 'gravity-loss', termKey: 'designer_v2.glossary.term.gravity_loss', bodyKey: 'designer_v2.glossary.body.gravity_loss', category: 'performance' },
+  { id: 'suborbital', termKey: 'designer_v2.glossary.term.suborbital', bodyKey: 'designer_v2.glossary.body.suborbital', category: 'orbit' },
+  { id: 'orbit-leo', termKey: 'designer_v2.glossary.term.orbit_leo', bodyKey: 'designer_v2.glossary.body.orbit_leo', category: 'orbit' },
+  { id: 'orbit-iss', termKey: 'designer_v2.glossary.term.orbit_iss', bodyKey: 'designer_v2.glossary.body.orbit_iss', category: 'orbit' },
+  { id: 'orbit-meo', termKey: 'designer_v2.glossary.term.orbit_meo', bodyKey: 'designer_v2.glossary.body.orbit_meo', category: 'orbit' },
+  { id: 'orbit-geo', termKey: 'designer_v2.glossary.term.orbit_geo', bodyKey: 'designer_v2.glossary.body.orbit_geo', category: 'orbit' },
+  { id: 'orbit-gto', termKey: 'designer_v2.glossary.term.orbit_gto', bodyKey: 'designer_v2.glossary.body.orbit_gto', category: 'orbit' },
+  { id: 'orbit-tli', termKey: 'designer_v2.glossary.term.orbit_tli', bodyKey: 'designer_v2.glossary.body.orbit_tli', category: 'orbit' },
+  { id: 'mars-transfer', termKey: 'designer_v2.glossary.term.mars_transfer', bodyKey: 'designer_v2.glossary.body.mars_transfer', category: 'orbit' },
+  { id: 'lunar-landing', termKey: 'designer_v2.glossary.term.lunar_landing', bodyKey: 'designer_v2.glossary.body.lunar_landing', category: 'orbit' },
+];
+
+function renderGlossaryTable() {
+  const tbody = document.getElementById('glossary-tbody');
+  if (!tbody) return;
+
+  tbody.innerHTML = GLOSSARY_TERMS.map((term) => {
+    const termText = t(term.termKey);
+    const bodyText = t(term.bodyKey);
+    const categoryText = t(`glossary.category.${term.category}`);
+    return `<tr id="${term.id}" data-glossary-row>
+      <td class="glossary-term-cell"><strong>${termText}</strong></td>
+      <td class="glossary-def-cell">${bodyText}</td>
+      <td class="glossary-cat-cell"><span class="glossary-category-badge glossary-cat-${term.category}">${categoryText}</span></td>
+    </tr>`;
+  }).join('');
+}
+
+function bindSearch() {
+  const input = document.getElementById('glossary-search');
+  if (!input) return;
+
+  input.addEventListener('input', () => {
+    const query = input.value.toLowerCase().trim();
+    const rows = document.querySelectorAll('#glossary-tbody tr');
+    for (const row of rows) {
+      const text = row.textContent.toLowerCase();
+      row.hidden = query !== '' && !text.includes(query);
+    }
+  });
+}
+
+function init() {
+  initPage({
+    titleKey: 'glossary.title',
+  });
+
+  renderGlossaryTable();
+  bindSearch();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -345,5 +345,15 @@
   "designer_v2.target.tli": "TLI (12.4 km/s)",
   "designer_v2.engine_card.sea_level_na": "Sea-level data not applicable",
   "site.title": "Rocket Equation",
-  "nav.glossary": "Flight glossary"
+  "nav.glossary": "Flight glossary",
+  "glossary.title": "Flight Glossary",
+  "glossary.subtitle": "Quick reference for all the terms used across the rocket design tools.",
+  "glossary.search_placeholder": "Filter terms…",
+  "glossary.col.term": "Term",
+  "glossary.col.definition": "Definition",
+  "glossary.col.category": "Category",
+  "glossary.category.equation": "Equation",
+  "glossary.category.performance": "Performance",
+  "glossary.category.stage": "Stage",
+  "glossary.category.orbit": "Orbit"
 }

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -343,5 +343,7 @@
   "designer_v2.footer.prefix": "Advanced rocket designer ·",
   "designer_v2.target.gto": "GTO (11.8 km/s)",
   "designer_v2.target.tli": "TLI (12.4 km/s)",
-  "designer_v2.engine_card.sea_level_na": "Sea-level data not applicable"
+  "designer_v2.engine_card.sea_level_na": "Sea-level data not applicable",
+  "site.title": "Rocket Equation",
+  "nav.glossary": "Flight glossary"
 }

--- a/docs/i18n/zh.json
+++ b/docs/i18n/zh.json
@@ -343,5 +343,7 @@
   "designer_v2.footer.prefix": "高级火箭设计器 ·",
   "designer_v2.target.gto": "GTO（11.8 km/s）",
   "designer_v2.target.tli": "TLI（12.4 km/s）",
-  "designer_v2.engine_card.sea_level_na": "海平面数据不适用"
+  "designer_v2.engine_card.sea_level_na": "海平面数据不适用",
+  "site.title": "火箭方程",
+  "nav.glossary": "飞行术语表"
 }

--- a/docs/i18n/zh.json
+++ b/docs/i18n/zh.json
@@ -345,5 +345,15 @@
   "designer_v2.target.tli": "TLI（12.4 km/s）",
   "designer_v2.engine_card.sea_level_na": "海平面数据不适用",
   "site.title": "火箭方程",
-  "nav.glossary": "飞行术语表"
+  "nav.glossary": "飞行术语表",
+  "glossary.title": "飞行术语表",
+  "glossary.subtitle": "火箭设计工具中使用的所有术语的快速参考。",
+  "glossary.search_placeholder": "筛选术语…",
+  "glossary.col.term": "术语",
+  "glossary.col.definition": "定义",
+  "glossary.col.category": "类别",
+  "glossary.category.equation": "公式",
+  "glossary.category.performance": "性能",
+  "glossary.category.stage": "级段",
+  "glossary.category.orbit": "轨道"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,37 +15,23 @@
   </head>
 
   <body>
-    <header>
-      <h1 data-i18n="index.hero.title"></h1>
-      <p data-i18n="index.hero.subtitle"></p>
-
-      <nav aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
-        <div class="nav-row">
-          <ul>
-            <li><a href="./designer.html" data-i18n="nav.designer"></a></li>
-            <li><a href="./designer-v2.html" data-i18n="nav.designer_v2"></a></li>
-            <li><a href="#equation" data-i18n="nav.equation"></a></li>
-            <li><a href="#explanation" data-i18n="nav.explanation"></a></li>
-            <li><a href="#calculator" data-i18n="nav.calculator"></a></li>
-            <li><a href="#worked-example" data-i18n="nav.worked_example"></a></li>
-            <li><a href="#intuition" data-i18n="nav.intuition"></a></li>
-          </ul>
-          <div class="nav-controls">
-            <div class="theme-switcher">
-              <span class="theme-switcher-label" data-i18n="theme.label"></span>
-              <button type="button" class="theme-toggle" data-theme-toggle></button>
-            </div>
-            <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
-              <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
-              <span class="lang-switcher-separator">|</span>
-              <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
-            </div>
-          </div>
-        </div>
-      </nav>
-    </header>
 
     <main id="content">
+      <div class="page-hero">
+        <h1 data-i18n="index.hero.title"></h1>
+        <p data-i18n="index.hero.subtitle"></p>
+      </div>
+
+      <nav class="section-nav" aria-label="Page sections">
+        <ul>
+          <li><a href="#equation" data-i18n="nav.equation"></a></li>
+          <li><a href="#explanation" data-i18n="nav.explanation"></a></li>
+          <li><a href="#calculator" data-i18n="nav.calculator"></a></li>
+          <li><a href="#worked-example" data-i18n="nav.worked_example"></a></li>
+          <li><a href="#intuition" data-i18n="nav.intuition"></a></li>
+        </ul>
+      </nav>
+
       <section id="equation" aria-labelledby="equation-title">
         <h2 id="equation-title" data-i18n="index.equation.title"></h2>
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,4 @@
+import './site-header.js';
 import { formatMessage, initPage, t } from './lib/i18n.js';
 
 const G0 = 9.80665;

--- a/docs/site-header.js
+++ b/docs/site-header.js
@@ -1,0 +1,91 @@
+/**
+ * Shared site header — single source of truth for all pages.
+ * Imported as a side-effect module; injects the <header> element on load.
+ */
+
+const NAV_LINKS = [
+  { href: './index.html', i18nKey: 'nav.index' },
+  { href: './designer.html', i18nKey: 'nav.designer' },
+  { href: './designer-v2.html', i18nKey: 'nav.designer_v2' },
+  { href: './glossary.html', i18nKey: 'nav.glossary' },
+];
+
+function currentPageHref() {
+  if (typeof location === 'undefined') return '';
+  const path = location.pathname;
+  const filename = path.substring(path.lastIndexOf('/') + 1) || 'index.html';
+  return `./${filename}`;
+}
+
+function buildHeader() {
+  const header = document.createElement('header');
+  const activeHref = currentPageHref();
+
+  const titleLink = document.createElement('a');
+  titleLink.href = './index.html';
+  titleLink.className = 'site-title';
+  titleLink.setAttribute('data-i18n', 'site.title');
+  header.appendChild(titleLink);
+
+  const nav = document.createElement('nav');
+  nav.setAttribute('aria-label', 'Primary');
+  nav.setAttribute('data-i18n', 'nav.primary');
+  nav.setAttribute('data-i18n-attr', 'aria-label');
+
+  const navRow = document.createElement('div');
+  navRow.className = 'nav-row';
+
+  const ul = document.createElement('ul');
+  for (const link of NAV_LINKS) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = link.href;
+    a.setAttribute('data-i18n', link.i18nKey);
+    if (link.href === activeHref) {
+      a.setAttribute('aria-current', 'page');
+    }
+    li.appendChild(a);
+    ul.appendChild(li);
+  }
+  navRow.appendChild(ul);
+
+  const controls = document.createElement('div');
+  controls.className = 'nav-controls';
+  controls.innerHTML = `
+    <div class="theme-switcher">
+      <span class="theme-switcher-label" data-i18n="theme.label"></span>
+      <button type="button" class="theme-toggle" data-theme-toggle></button>
+    </div>
+    <div class="lang-switcher" data-i18n="nav.language_switcher" data-i18n-attr="aria-label">
+      <button type="button" data-set-lang="en" data-i18n="lang.english"></button>
+      <span class="lang-switcher-separator">|</span>
+      <button type="button" data-set-lang="zh" data-i18n="lang.chinese"></button>
+    </div>`;
+  navRow.appendChild(controls);
+
+  nav.appendChild(navRow);
+  header.appendChild(nav);
+
+  return header;
+}
+
+export function injectSiteHeader() {
+  if (typeof document === 'undefined') return;
+
+  const existing = document.querySelector('header');
+  if (existing) return;
+
+  const header = buildHeader();
+  const body = document.body;
+  if (body) {
+    body.prepend(header);
+  }
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectSiteHeader, { once: true });
+  } else {
+    injectSiteHeader();
+  }
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -199,6 +199,63 @@ header > * {
   margin-right: auto;
 }
 
+.site-title {
+  display: block;
+  font-family: var(--display-font);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  text-decoration: none;
+  margin-bottom: 0.5rem;
+}
+
+.site-title:hover {
+  color: var(--primary);
+}
+
+.page-hero {
+  grid-column: 1 / -1;
+}
+
+.page-hero h1 {
+  margin-bottom: 0.35rem;
+}
+
+.page-hero p {
+  max-width: 42rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.02rem;
+}
+
+.section-nav {
+  grid-column: 1 / -1;
+}
+
+.section-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.section-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: var(--surface-strong);
+  color: var(--text);
+  text-decoration: none;
+  border: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
 main#content {
   max-width: 70rem;
   margin: 0 auto;
@@ -647,13 +704,6 @@ footer a {
 
 footer a:hover {
   color: var(--primary-hover);
-}
-
-header > p {
-  max-width: 42rem;
-  margin: 0 0 0.15rem 0;
-  color: var(--muted);
-  font-size: 1.02rem;
 }
 
 section h2 + p,


### PR DESCRIPTION
## Summary

Closes #104

Extracts the page header into a single-source-of-truth JS module (docs/site-header.js) that injects an identical nav bar on all pages.

## Approach
Chose JS-rendered header (over hand-maintained duplicate markup) for true single source of truth - one file to edit, no drift risk, auto-detects current page for aria-current marking.

## Changes
- New docs/site-header.js: builds and injects unified header with site title, 4 nav links, theme toggle, lang switcher
- Removed hardcoded header from index.html, designer.html, designer-v2.html
- Moved page-specific H1/subtitle into .page-hero div inside main
- Added section-nav for index.html anchor links
- Added i18n keys: site.title, nav.glossary (EN + ZH, 347 keys each)
- Added CSS: .site-title, .page-hero, .section-nav
- Updated smoke test for unified header structure

## How to verify (manual)
1. Load each page - headers look identical
2. Click each nav link - navigates correctly, active state updates
3. Toggle dark mode on one page, reload another - preference persisted
4. Switch to Chinese on one page, reload another - language persisted
5. DOM check: header outerHTML same nav structure on all pages (modulo aria-current)

Pre-push self-check passed: f9ffdb2, 11 files