### PR TITLE
Remove inline glossary panel from designer-v2 (moved to glossary.html)

### DIFF
--- a/docs/designer-v2.css
+++ b/docs/designer-v2.css
@@ -20,25 +20,7 @@
   gap: 1.35rem;
 }
 
-.designer-v2-glossary-panel {
-  display: grid;
-  gap: 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 1.05rem;
-  background: var(--surface-muted);
-  box-shadow: var(--shadow-card);
-}
-
-.designer-v2-glossary-panel h2 {
-  margin: 0;
-}
-
-.designer-v2-glossary-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
+/* Glossary panel removed — terms live on glossary.html now */
 
 .designer-v2-glossary-item {
   position: relative;

--- a/docs/designer-v2.html
+++ b/docs/designer-v2.html
@@ -27,11 +27,6 @@
           <p data-i18n="designer_v2.intro.body"></p>
         </section>
 
-        <section class="designer-v2-glossary-panel" aria-labelledby="designer-v2-glossary-title">
-          <h2 id="designer-v2-glossary-title" data-i18n="designer_v2.glossary.title"></h2>
-          <p class="muted" data-i18n="designer_v2.glossary.note"></p>
-          <div id="glossary-list" class="designer-v2-glossary-list"></div>
-        </section>
 
         <section aria-labelledby="designer-v2-controls-title">
           <div class="designer-v2-toolbar">

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -226,7 +226,7 @@ describe('designer-v2 smoke flow', () => {
     });
   });
 
-  it('opens glossary tooltips on focus and closes them on Escape', async () => {
+  it('inline glossary tooltips open on focus and close on Escape', async () => {
     await loadDesignerV2Page();
 
     const glossaryTrigger = document.querySelector('[data-glossary-trigger="delta-v"]');
@@ -236,7 +236,6 @@ describe('designer-v2 smoke flow', () => {
     expect(glossaryTrigger).not.toBeNull();
     expect(glossaryItem).not.toBeNull();
     expect(glossaryTooltip).not.toBeNull();
-    expect(document.querySelectorAll('#glossary-list [data-glossary-item]')).toHaveLength(22);
 
     glossaryTrigger.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 
@@ -254,10 +253,18 @@ describe('designer-v2 smoke flow', () => {
     });
   });
 
-  it('renders glossary trigger labels as translated text, not raw i18n keys', async () => {
+  it('standalone glossary panel is removed (terms live on glossary.html)', async () => {
     await loadDesignerV2Page();
 
-    const triggers = document.querySelectorAll('#glossary-list [data-glossary-trigger]');
+    expect(document.querySelector('[aria-label="Flight glossary"], .glossary-region')).toBeNull();
+    expect(document.querySelector('.designer-v2-glossary-panel')).toBeNull();
+    expect(document.getElementById('glossary-list')).toBeNull();
+  });
+
+  it('renders inline glossary trigger labels as translated text, not raw i18n keys', async () => {
+    await loadDesignerV2Page();
+
+    const triggers = document.querySelectorAll('[data-glossary-trigger]');
     expect(triggers.length).toBeGreaterThan(0);
 
     for (const trigger of triggers) {


### PR DESCRIPTION
## Summary

Closes #106

Removes the standalone Flight glossary panel from `designer-v2.html` — all 22 terms now live exclusively on the dedicated `glossary.html` page (shipped in PR #108).

## Changes
- **designer-v2.html**: Removed `<section class="designer-v2-glossary-panel">` (the inline glossary region with 22 button triggers)
- **designer-v2.css**: Removed `.designer-v2-glossary-panel`, `.designer-v2-glossary-panel h2`, and `.designer-v2-glossary-list` rules
- **designer-v2.smoke.test.js**: Updated existing tooltip tests to work with inline triggers only; added acceptance test verifying panel removal (`document.querySelector('.designer-v2-glossary-panel')` returns null)

## Design decision
Inline tooltip triggers (`withGlossaryTerm`, `glossaryInlineMarkup`) **remain** in card content (e.g. Δv, TWR labels). These provide contextual hover/focus help right where users see the term. The standalone panel was redundant now that the dedicated glossary page exists.

## Acceptance criteria verification
- ✅ `document.querySelector('[aria-label="Flight glossary"], .glossary-region')` returns null on designer-v2
- ✅ `document.querySelector('.designer-v2-glossary-panel')` returns null
- ✅ `document.getElementById('glossary-list')` returns null
- ✅ Inline glossary tooltips still function (open on focus, close on Escape)
- ✅ 65 tests pass

Pre-push self-check passed: a43fa84, files: designer-v2.css, designer-v2.html, designer-v2.smoke.test.js