### PR TITLE
Prevent silhouette sidebar from occluding Mission desk on scroll

### DIFF
--- a/docs/designer-v2.css
+++ b/docs/designer-v2.css
@@ -11,7 +11,6 @@
 @media (min-width: 1080px) {
   .designer-v2-layout {
     grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 0.95fr);
-    align-items: start;
   }
 }
 
@@ -587,9 +586,11 @@
 }
 
 @media (min-width: 1080px) {
-  .designer-v2-summary-panel {
+  .designer-v2-sidebar {
     position: sticky;
     top: 1rem;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
   }
 }
 

--- a/docs/designer-v2.smoke.test.js
+++ b/docs/designer-v2.smoke.test.js
@@ -508,4 +508,14 @@ describe('designer-v2 smoke flow', () => {
     expect(css).toContain("math[display='block']");
   });
 
+  it('constrains sidebar sticky height to prevent silhouette occluding mission desk', async () => {
+    const cssPath = path.join(docsDir, 'designer-v2.css');
+    const css = await fs.readFile(cssPath, 'utf-8');
+
+    // Sidebar uses sticky positioning with max-height constraint at desktop width
+    expect(css).toMatch(/\.designer-v2-sidebar\s*\{[^}]*position:\s*sticky/);
+    expect(css).toMatch(/\.designer-v2-sidebar\s*\{[^}]*max-height:\s*calc\(100vh\s*-\s*2rem\)/);
+    expect(css).toMatch(/\.designer-v2-sidebar\s*\{[^}]*overflow-y:\s*auto/);
+  });
+
 });


### PR DESCRIPTION
## Summary

Closes #105

Prevents the rocket silhouette sidebar from overlapping the Mission desk content when scrolling on desktop viewports.

## Approach chosen: (c) — Constrain max-height + scrollability

Moved sticky positioning from `.designer-v2-summary-panel` to the entire `.designer-v2-sidebar` wrapper, with:
- `max-height: calc(100vh - 2rem)` — sidebar never exceeds viewport height
- `overflow-y: auto` — if sidebar content is taller than viewport, users can scroll within it
- Removed `align-items: start` from grid layout so the sidebar grid cell stretches to match the main column height, enabling proper sticky scrolling within bounds

**Why this approach**: Simpler than approach (a) (no HTML restructuring needed) and more reliable than (b) (works at all viewport heights, not just a threshold). The sidebar sticks while scrolling through the Vehicle builder section but physically cannot grow taller than the viewport, so it never occludes Mission desk content below.

## Changes
- **designer-v2.css**: Moved sticky from `.designer-v2-summary-panel` to `.designer-v2-sidebar` with max-height + overflow constraints; removed `align-items: start` from grid layout
- **designer-v2.smoke.test.js**: Added CSS-based test verifying sticky + max-height + overflow-y rules on sidebar

## Manual verification checklist
- [x] Desktop 1280×800: sidebar sticks while scrolling through Vehicle builder
- [x] Mission desk header enters viewport → sidebar does not overlap
- [x] Sidebar content scrollable if it exceeds viewport height
- [x] Mobile 375×667: silhouette hidden (existing `display: none` at ≤720px), no regression
- [x] 66 tests pass

Pre-push self-check passed: 2ec4184, files: designer-v2.css, designer-v2.smoke.test.js